### PR TITLE
Prevent updating rows above current viewport

### DIFF
--- a/src/core/scroll.c
+++ b/src/core/scroll.c
@@ -157,7 +157,7 @@ UBYTE scroll_viewport(parallax_row_t * port) {
         } else if (current_row == new_row + 1) {
             // Queue top row
             UBYTE x = MAX(0, new_col - SCREEN_PAD_LEFT);
-            UBYTE y = MAX(0, new_row - SCREEN_PAD_TOP);
+            UBYTE y = MAX(port->start_tile, new_row - SCREEN_PAD_TOP);
             scroll_queue_row(x, y);
             activate_actors_in_row(x, y);
         } else if (current_row != new_row) {


### PR DESCRIPTION
This is the GBVM counterpart to [gbstudio/1009](https://github.com/chrismaltby/gb-studio/pull/1009) .

Makes it possible to have vertical scrolling in the last parallax viewport, allowing the use of a fixed position parallax viewport heads up display with more freedom of movement. The scene height must be no more than 256 pixels (32 tiles).

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Enables vertical scrolling in the last (either second or third) parallax viewport. While this may act strangely with standard parallax backgrounds, it will enable top-of-the-screen HUD elements in a fixed position parallax viewport. 


* **What is the current behavior?** (You can also link to an open issue here)
While a scene taller than 144px will have vertical scrolling, it will erroneously overwrite tiles in the fixed viewport, thereby corrupting the HUD. Also, in order to have vertical scrolling, one must enable three parallax layers, which means the HUD can be no smaller than 2 tiles, made up of two layers.


* **What is the new behavior (if this is a feature change)?**
The fixed viewport is not updated when scrolling, so it can be used for a tile-based HUD. Vertical scrolling is now enabled on the bottommost parallax viewport whether 2 or 3 are enabled.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
I don't believe so.


* **Other information**:
This is only really helpful for a very specific use case, but I don't think it harms normal functionality, so I don't see any reason not to add it.