### PR TITLE
Actor slide motion on move_to command fix

### DIFF
--- a/src/core/vm_actor.c
+++ b/src/core/vm_actor.c
@@ -56,6 +56,8 @@ void vm_actor_move_to(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
     if (THIS->flags == 0) {
         THIS->flags = MOVE_ACTIVE;
         actor->movement_interrupt = FALSE;
+        // Switch to moving animation frames
+        actor_set_anim_moving(actor);
 
         // Snap to nearest pixel before moving
         actor->pos.x = ((actor->pos.x >> 4) << 4);


### PR DESCRIPTION
Added a line in vm_actor move_to function to switch to the movement spritesheet frames on moving start, which fixed the actor idle on moving animation issue. Issue is talked about [in issue 915 on GB Studio](https://github.com/chrismaltby/gb-studio/issues/915#issuecomment-1139893462), but since it's part of the underlying gbvm logic chain I thought it would be more helpful to do the pull request here. 