### PR TITLE
Fadein for EXCEPTION_LOAD must now be handled in resumed GBVM script,…

### DIFF
--- a/src/core/core.c
+++ b/src/core/core.c
@@ -137,7 +137,8 @@ void process_VM(void) {
                         remove_LCD_ISRs();
                         // load game state from SRAM
                         vm_loaded_state = data_load(ReadBankedUBYTE(vm_exception_params_offset, vm_exception_params_bank));
-                        fade_in = !(load_scene(current_scene.ptr, current_scene.bank, FALSE));
+                        load_scene(current_scene.ptr, current_scene.bank, FALSE);
+                        fade_in = FALSE;
                         break;
                     }
                     default: {


### PR DESCRIPTION
… allowing for save data "On Load" scripts defined in GB Studio to be run before the scene fades in