### PR TITLE
Fixes vm_projectile_load_type only loading from slot 0

### DIFF
--- a/src/core/vm_projectiles.c
+++ b/src/core/vm_projectiles.c
@@ -24,7 +24,7 @@ void vm_projectile_load_type(SCRIPT_CTX * THIS, UBYTE type, UBYTE projectile_def
     projectile_def_t * current_def = projectile_defs + type;
     far_ptr_t scene_sprites;
     ReadBankedFarPtr(&scene_sprites, (const unsigned char *)&((scene_t *)current_scene.ptr)->sprites, current_scene.bank);
-    MemcpyBanked(current_def, projectile_def, sizeof(projectile_def_t), projectile_def_bank);
+    MemcpyBanked(current_def, projectile_def + type, sizeof(projectile_def_t), projectile_def_bank);
     UBYTE idx = IndexOfFarPtr(scene_sprites.ptr, scene_sprites.bank, sprites_len, &current_def->sprite);
     current_def->base_tile = (idx < sprites_len) ? scene_sprites_base_tiles[idx] : 0;
 }


### PR DESCRIPTION
The way VM_PROJECTILE_LOAD_TYPE currently works is that it only loads the first projectile type from the specified projectile definitions regardless of what is chosen in the TYPE parameter.

This PR fixes it so the type specified in the TYPE parameter is loaded.