### PR TITLE
Optimize point_translate_dir functions to avoid multiplications

### DIFF
--- a/include/math.h
+++ b/include/math.h
@@ -92,17 +92,28 @@ typedef enum {
 } direction_e;
 
 extern const int8_t sine_wave[256];
-extern const point8_t dir_lookup[4];
 extern const uint8_t dir_angle_lookup[4];
 
 inline void point_translate_dir(point16_t *point, direction_e dir, uint8_t speed) {
-    point->x += (int16_t)(dir_lookup[dir].x * speed);
-    point->y += (int16_t)(dir_lookup[dir].y * speed);
+    if(dir == DIR_RIGHT)
+        point->x += speed;
+    else if(dir == DIR_LEFT)
+        point->x -= speed;
+    else if(dir == DIR_DOWN)
+        point->y += speed;
+    else if(dir == DIR_UP)
+        point->y -= speed;
 }
 
 inline void point_translate_dir_word(point16_t *point, direction_e dir, uint16_t speed) {
-    point->x += (int16_t)(dir_lookup[dir].x * speed);
-    point->y += (int16_t)(dir_lookup[dir].y * speed);
+    if(dir == DIR_RIGHT)
+        point->x += speed;
+    else if(dir == DIR_LEFT)
+        point->x -= speed;
+    else if(dir == DIR_DOWN)
+        point->y += speed;
+    else if(dir == DIR_UP)
+        point->y -= speed;
 }
 
 inline void point_translate_angle(point16_t *point, uint8_t angle, uint8_t speed) {

--- a/src/core/math.c
+++ b/src/core/math.c
@@ -19,13 +19,6 @@ const int8_t sine_wave[256] = {
     -49, -46,  -43, -40, -37, -34, -31, -28, -25, -22, -19, -16, -12,  -9,  -6,  -3
 };
 
-const point8_t dir_lookup[4] = {
-    { .x =  0, .y =  1 },
-    { .x =  1, .y =  0 },
-    { .x =  0, .y = -1 },
-    { .x = -1, .y =  0 }
-};
-
 const UBYTE dir_angle_lookup[4] = {
     128,
     64,


### PR DESCRIPTION
- Optimize point_translate_dir to use conditionals instead of LUT+MUL

- Optimize point_translate_dir the same way

- Remove now-unused LUT "dir_lookup"