### PR TITLE
Split non-runtime parts of actor_t into a separate struct for compiled data

### DIFF
--- a/include/gbs_types.h
+++ b/include/gbs_types.h
@@ -32,6 +32,36 @@ typedef struct animation_t
     uint8_t end;
 } animation_t;
 
+// Compiled actor definition in ROM
+typedef struct actor_def_t
+{
+    bool active               : 1;
+    bool pinned               : 1;
+    bool hidden               : 1;
+    bool disabled             : 1;
+    bool anim_noloop          : 1;
+    bool collision_enabled    : 1;
+    bool movement_interrupt   : 1;
+    bool persistent           : 1;
+    point16_t pos;
+    direction_e dir;
+    bounding_box_t bounds;
+    uint8_t base_tile;
+    uint8_t frame;
+    uint8_t frame_start;
+    uint8_t frame_end;
+    uint8_t anim_tick;
+    uint8_t move_speed;
+    uint8_t animation;
+    uint8_t reserve_tiles;
+    animation_t animations[8];
+    far_ptr_t sprite;
+    far_ptr_t script, script_update;
+    // Collisions
+    collision_group_e collision_group;
+} actor_def_t;
+
+// Runtime actor representation in RAM
 typedef struct actor_t
 {
     bool active               : 1;

--- a/src/core/data_manager.c
+++ b/src/core/data_manager.c
@@ -55,6 +55,36 @@ void load_init(void) BANKED {
     scene_stack_ptr = scene_stack;
 }
 
+void load_actor_from_def(actor_t* actor, actor_def_t* actor_def) BANKED {
+    memset(actor, 0, sizeof(actor_t));
+    actor->active = actor_def->active;
+    actor->pinned = actor_def->pinned;
+    actor->hidden = actor_def->hidden;
+    actor->disabled = actor_def->disabled;
+    actor->anim_noloop = actor_def->anim_noloop;
+    actor->collision_enabled = actor_def->collision_enabled;
+    actor->movement_interrupt = actor_def->movement_interrupt;
+    actor->persistent = actor_def->persistent;
+    actor->pos = actor_def->pos;
+    actor->dir = actor_def->dir;
+    actor->bounds = actor_def->bounds;
+    actor->base_tile = actor_def->base_tile;
+    actor->frame = actor_def->frame;
+    actor->frame_start = actor_def->frame_start;
+    actor->frame_end = actor_def->frame_end;
+    actor->anim_tick = actor_def->anim_tick;
+    actor->move_speed = actor_def->move_speed;
+    actor->animation = actor_def->animation;
+    actor->reserve_tiles = actor_def->reserve_tiles;
+    for(uint8_t i = 0; i < 8; i++) {
+        actor->animations[i] = actor_def->animations[i];
+    }
+    actor->sprite = actor_def->sprite;
+    actor->script = actor_def->script;
+    actor->script_update = actor_def->script_update;
+    actor->collision_group = actor_def->collision_group;
+}
+
 void load_bkg_tileset(const tileset_t* tiles, UBYTE bank) BANKED {
     if ((!bank) || (!tiles)) return;
 
@@ -268,9 +298,12 @@ UBYTE load_scene(const scene_t * scene, UBYTE bank, UBYTE init_data) BANKED {
 
         // Add other actors, activate pinned
         if (actors_len != 0) {
+            actor_def_t actor_def_temp_ram;
+            actor_def_t* p_actor_def = scn.actors.ptr;
             actor_t * actor = actors + 1;
-            MemcpyBanked(actor, scn.actors.ptr, sizeof(actor_t) * (actors_len - 1), scn.actors.bank);
-            for (i = actors_len - 1; i != 0; i--, actor++) {
+            for (i = 0; i < actors_len-1; i++, p_actor_def++, actor++) {
+                MemcpyBanked(&actor_def_temp_ram, p_actor_def, sizeof(actor_def_t), scn.actors.bank);
+                load_actor_from_def(actor, &actor_def_temp_ram);
                 if (actor->reserve_tiles) {
                     // exclusive sprites allocated separately to avoid overwriting if modified
                     actor->base_tile = allocated_sprite_tiles;


### PR DESCRIPTION
- Add struct actor_def_t, replicating everything except runtime state

- Add new BANKED function load_actor_from_def to initialize an actor_t from an actor_def_t

- Call load_actor_from_def in load_scene, using temporary RAM storage to avoid repeated bankswitch