### PR TITLE
Fix performance issues with actor_def_t -> actor_t copies

### DIFF
--- a/include/gbs_types.h
+++ b/include/gbs_types.h
@@ -41,6 +41,8 @@ typedef struct actor_def_t
     bool anim_noloop          : 1;
     bool collision_enabled    : 1;
     bool persistent           : 1;
+    bool active               : 1;
+    bool movement_interrupt   : 1;
     point16_t pos;
     direction_e dir;
     bounding_box_t bounds;
@@ -56,33 +58,14 @@ typedef struct actor_def_t
 // Runtime actor representation in RAM
 typedef struct actor_t
 {
-    bool active               : 1;
-    bool pinned               : 1;
-    bool hidden               : 1;
-    bool disabled             : 1;
-    bool anim_noloop          : 1;
-    bool collision_enabled    : 1;
-    bool movement_interrupt   : 1;
-    bool persistent           : 1;
-    point16_t pos;
-    direction_e dir;
-    bounding_box_t bounds;
+    actor_def_t def;
     uint8_t base_tile;
     uint8_t frame;
     uint8_t frame_start;
     uint8_t frame_end;
-    uint8_t anim_tick;
-    uint8_t move_speed;
     uint8_t animation;
-    uint8_t reserve_tiles;
     animation_t animations[8];
-    far_ptr_t sprite;
-    far_ptr_t script, script_update;
     uint16_t hscript_update, hscript_hit;
-
-    // Collisions
-    collision_group_e collision_group;
-
     // Linked list
     struct actor_t *next;
     struct actor_t *prev;

--- a/src/core/camera.c
+++ b/src/core/camera.c
@@ -28,7 +28,7 @@ void camera_init(void) BANKED {
 void camera_update(void) BANKED {
     if (camera_settings & CAMERA_LOCK_X_FLAG)
     {
-        WORD target_pos = PLAYER.pos.x + CAMERA_FIXED_OFFSET_X;
+        WORD target_pos = PLAYER.def.pos.x + CAMERA_FIXED_OFFSET_X;
         WORD tolerance = PX_TO_SUBPX(camera_deadzone_x + camera_offset_x);
         WORD new_cam_pos = camera_x;
 
@@ -53,7 +53,7 @@ void camera_update(void) BANKED {
 
     if (camera_settings & CAMERA_LOCK_Y_FLAG)
     {
-        WORD target_pos = PLAYER.pos.y + CAMERA_FIXED_OFFSET_Y;
+        WORD target_pos = PLAYER.def.pos.y + CAMERA_FIXED_OFFSET_Y;
         WORD tolerance = PX_TO_SUBPX(camera_deadzone_y + camera_offset_y);
         WORD new_cam_pos = camera_y;
 

--- a/src/core/projectiles.c
+++ b/src/core/projectiles.c
@@ -66,10 +66,10 @@ void projectiles_update(void) NONBANKED {
 
         if (IS_FRAME_EVEN) {
             actor_t *hit_actor = actor_overlapping_bb(&projectile->def.bounds, &projectile->pos, NULL, FALSE);
-            if (hit_actor && (hit_actor->collision_group & projectile->def.collision_mask)) {
+            if (hit_actor && (hit_actor->def.collision_group & projectile->def.collision_mask)) {
                 // Hit! - Fire collision script here
-                if ((hit_actor->script.bank) && (hit_actor->hscript_hit & SCRIPT_TERMINATED)) {
-                    script_execute(hit_actor->script.bank, hit_actor->script.ptr, &(hit_actor->hscript_hit), 1, (UWORD)(projectile->def.collision_group));
+                if ((hit_actor->def.script.bank) && (hit_actor->hscript_hit & SCRIPT_TERMINATED)) {
+                    script_execute(hit_actor->def.script.bank, hit_actor->def.script.ptr, &(hit_actor->hscript_hit), 1, (UWORD)(projectile->def.collision_group));
                 }
                 if (!projectile->def.strong) {
                     // Remove projectile

--- a/src/core/vm_actor.c
+++ b/src/core/vm_actor.c
@@ -61,14 +61,14 @@ void vm_actor_move_to(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
     actor = actors + (UBYTE)(params->ID);
 
     if (THIS->flags == 0) {
-        actor->movement_interrupt = FALSE;
+        actor->def.movement_interrupt = FALSE;
 
         // Switch to moving animation frames
         actor_set_anim_moving(actor);
 
         // Snap to nearest pixel before moving
-        actor->pos.x = SUBPX_SNAP_PX(actor->pos.x);
-        actor->pos.y = SUBPX_SNAP_PX(actor->pos.y);
+        actor->def.pos.x = SUBPX_SNAP_PX(actor->def.pos.x);
+        actor->def.pos.y = SUBPX_SNAP_PX(actor->def.pos.y);
 
         if (CHK_FLAG(params->ATTR, ACTOR_ATTR_DIAGONAL)) {
             SET_FLAG(THIS->flags, MOVE_ALLOW_H | MOVE_ALLOW_V);
@@ -81,78 +81,78 @@ void vm_actor_move_to(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
         // If moving relative add current position
         // and snap destination to either pixels/tiles
         if (CHK_FLAG(params->ATTR, ACTOR_ATTR_RELATIVE_SNAP_PX)) {
-            params->X = SUBPX_SNAP_PX(params->X + actor->pos.x);
-            params->Y = SUBPX_SNAP_PX(params->Y + actor->pos.y);
+            params->X = SUBPX_SNAP_PX(params->X + actor->def.pos.x);
+            params->Y = SUBPX_SNAP_PX(params->Y + actor->def.pos.y);
         } else if (CHK_FLAG(params->ATTR, ACTOR_ATTR_RELATIVE_SNAP_TILE)) {
-            params->X = SUBPX_SNAP_TILE(params->X + actor->pos.x);
-            params->Y = SUBPX_SNAP_TILE(params->Y + actor->pos.y);
+            params->X = SUBPX_SNAP_TILE(params->X + actor->def.pos.x);
+            params->Y = SUBPX_SNAP_TILE(params->Y + actor->def.pos.y);
         }
 
         // Check for collisions in path
         if (CHK_FLAG(params->ATTR, ACTOR_ATTR_CHECK_COLL)) {
             if (CHK_FLAG(params->ATTR, ACTOR_ATTR_H_FIRST)) {
                 // Check for horizontal collision
-                if (actor->pos.x != params->X) {
-                    UBYTE check_dir = (actor->pos.x > params->X) ? CHECK_DIR_LEFT : CHECK_DIR_RIGHT;
-                    params->X = check_collision_in_direction(actor->pos.x, actor->pos.y, &actor->bounds, params->X, check_dir);
+                if (actor->def.pos.x != params->X) {
+                    UBYTE check_dir = (actor->def.pos.x > params->X) ? CHECK_DIR_LEFT : CHECK_DIR_RIGHT;
+                    params->X = check_collision_in_direction(actor->def.pos.x, actor->def.pos.y, &actor->def.bounds, params->X, check_dir);
                 }
                 // Check for vertical collision
-                if (actor->pos.y != params->Y) {
-                    UBYTE check_dir = (actor->pos.y > params->Y) ? CHECK_DIR_UP : CHECK_DIR_DOWN;
-                    params->Y = check_collision_in_direction(params->X, actor->pos.y, &actor->bounds, params->Y, check_dir);
+                if (actor->def.pos.y != params->Y) {
+                    UBYTE check_dir = (actor->def.pos.y > params->Y) ? CHECK_DIR_UP : CHECK_DIR_DOWN;
+                    params->Y = check_collision_in_direction(params->X, actor->def.pos.y, &actor->def.bounds, params->Y, check_dir);
                 }
             } else {
                 // Check for vertical collision
-                if (actor->pos.y != params->Y) {
-                    UBYTE check_dir = (actor->pos.y > params->Y) ? CHECK_DIR_UP : CHECK_DIR_DOWN;
-                    params->Y = check_collision_in_direction(actor->pos.x, actor->pos.y, &actor->bounds, params->Y, check_dir);
+                if (actor->def.pos.y != params->Y) {
+                    UBYTE check_dir = (actor->def.pos.y > params->Y) ? CHECK_DIR_UP : CHECK_DIR_DOWN;
+                    params->Y = check_collision_in_direction(actor->def.pos.x, actor->def.pos.y, &actor->def.bounds, params->Y, check_dir);
                 }
                 // Check for horizontal collision
-                if (actor->pos.x != params->X) {
-                    UBYTE check_dir = (actor->pos.x > params->X) ? CHECK_DIR_LEFT : CHECK_DIR_RIGHT;
-                    params->X = check_collision_in_direction(actor->pos.x, params->Y, &actor->bounds, params->X, check_dir);
+                if (actor->def.pos.x != params->X) {
+                    UBYTE check_dir = (actor->def.pos.x > params->X) ? CHECK_DIR_LEFT : CHECK_DIR_RIGHT;
+                    params->X = check_collision_in_direction(actor->def.pos.x, params->Y, &actor->def.bounds, params->X, check_dir);
                 }
             }
         }
 
         // Actor already at destination
-        if ((actor->pos.x != params->X)) {
+        if ((actor->def.pos.x != params->X)) {
             SET_FLAG(THIS->flags, MOVE_NEEDED_H);
         } else {
             SET_FLAG(THIS->flags, MOVE_ALLOW_V);
         }
-        if (actor->pos.y != params->Y) {
+        if (actor->def.pos.y != params->Y) {
             SET_FLAG(THIS->flags, MOVE_NEEDED_V);
         } else {
             SET_FLAG(THIS->flags, MOVE_ALLOW_H);
         }
 
         // Initialise movement directions
-        if (actor->pos.x > params->X) {
+        if (actor->def.pos.x > params->X) {
             // Move left
             SET_FLAG(THIS->flags, MOVE_DIR_H);
         }
-        if (actor->pos.y > params->Y) {
+        if (actor->def.pos.y > params->Y) {
             // Move up
             SET_FLAG(THIS->flags, MOVE_DIR_V);
         }
     }
 
     // Interrupt actor movement
-    if (actor->movement_interrupt) {
+    if (actor->def.movement_interrupt) {
         // Set new X destination to next tile
-        if ((actor->pos.x < params->X) && (actor->pos.x & TILE_FRACTION_MASK)) {   // Bitmask to check for non-grid-aligned position
-            params->X = (actor->pos.x & ~TILE_FRACTION_MASK) + ONE_TILE_DISTANCE;  // If moving in positive direction, round up to next tile
+        if ((actor->def.pos.x < params->X) && (actor->def.pos.x & TILE_FRACTION_MASK)) {   // Bitmask to check for non-grid-aligned position
+            params->X = (actor->def.pos.x & ~TILE_FRACTION_MASK) + ONE_TILE_DISTANCE;  // If moving in positive direction, round up to next tile
         } else {
-            params->X = actor->pos.x  & ~TILE_FRACTION_MASK;                       // Otherwise, round down
+            params->X = actor->def.pos.x  & ~TILE_FRACTION_MASK;                       // Otherwise, round down
         }
         // Set new Y destination to next tile
-        if ((actor->pos.y < params->Y) && (actor->pos.y & TILE_FRACTION_MASK)) {
-            params->Y = (actor->pos.y & ~TILE_FRACTION_MASK) + ONE_TILE_DISTANCE;
+        if ((actor->def.pos.y < params->Y) && (actor->def.pos.y & TILE_FRACTION_MASK)) {
+            params->Y = (actor->def.pos.y & ~TILE_FRACTION_MASK) + ONE_TILE_DISTANCE;
         } else {
-            params->Y = actor->pos.y  & ~TILE_FRACTION_MASK;
+            params->Y = actor->def.pos.y  & ~TILE_FRACTION_MASK;
         }
-        actor->movement_interrupt = FALSE;
+        actor->def.movement_interrupt = FALSE;
     }
 
     // Move in X Axis
@@ -161,11 +161,11 @@ void vm_actor_move_to(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
         new_dir = CHK_FLAG(THIS->flags, MOVE_DIR_H) ? DIR_LEFT : DIR_RIGHT;
 
         // Move actor
-        point_translate_dir(&actor->pos, new_dir, actor->move_speed);
+        point_translate_dir(&actor->def.pos, new_dir, actor->def.move_speed);
 
         // Check for actor collision
-        if (CHK_FLAG(params->ATTR, ACTOR_ATTR_CHECK_COLL) && actor_overlapping_bb(&actor->bounds, &actor->pos, actor, FALSE)) {
-            point_translate_dir(&actor->pos, FLIPPED_DIR(new_dir), actor->move_speed);
+        if (CHK_FLAG(params->ATTR, ACTOR_ATTR_CHECK_COLL) && actor_overlapping_bb(&actor->def.bounds, &actor->def.pos, actor, FALSE)) {
+            point_translate_dir(&actor->def.pos, FLIPPED_DIR(new_dir), actor->def.move_speed);
             THIS->flags = 0;
             actor_set_anim_idle(actor);
             return;
@@ -179,11 +179,11 @@ void vm_actor_move_to(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
 
         // Check if overshot destination
         if (
-            (new_dir == DIR_LEFT && (actor->pos.x <= params->X)) || // Overshot left
-            (new_dir == DIR_RIGHT && (actor->pos.x >= params->X))   // Overshot right
+            (new_dir == DIR_LEFT && (actor->def.pos.x <= params->X)) || // Overshot left
+            (new_dir == DIR_RIGHT && (actor->def.pos.x >= params->X))   // Overshot right
         ) {
             // Reached Horizontal Destination
-            actor->pos.x = params->X;
+            actor->def.pos.x = params->X;
             SET_FLAG(THIS->flags, MOVE_ALLOW_V);
             CLR_FLAG(THIS->flags, MOVE_H);
         }
@@ -195,11 +195,11 @@ void vm_actor_move_to(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
         new_dir = CHK_FLAG(THIS->flags, MOVE_DIR_V) ? DIR_UP : DIR_DOWN;
 
         // Move actor
-        point_translate_dir(&actor->pos, new_dir, actor->move_speed);
+        point_translate_dir(&actor->def.pos, new_dir, actor->def.move_speed);
 
         // Check for actor collision
-        if (CHK_FLAG(params->ATTR, ACTOR_ATTR_CHECK_COLL) && actor_overlapping_bb(&actor->bounds, &actor->pos, actor, FALSE)) {
-            point_translate_dir(&actor->pos, FLIPPED_DIR(new_dir), actor->move_speed);
+        if (CHK_FLAG(params->ATTR, ACTOR_ATTR_CHECK_COLL) && actor_overlapping_bb(&actor->def.bounds, &actor->def.pos, actor, FALSE)) {
+            point_translate_dir(&actor->def.pos, FLIPPED_DIR(new_dir), actor->def.move_speed);
             THIS->flags = 0;
             actor_set_anim_idle(actor);
             return;
@@ -213,10 +213,10 @@ void vm_actor_move_to(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
 
         // Check if overshot destination
         if (
-            (new_dir == DIR_UP && (actor->pos.y <= params->Y)) || // Overshot above
-            (new_dir == DIR_DOWN &&  (actor->pos.y >= params->Y)) // Overshot below
+            (new_dir == DIR_UP && (actor->def.pos.y <= params->Y)) || // Overshot above
+            (new_dir == DIR_DOWN &&  (actor->def.pos.y >= params->Y)) // Overshot below
          ) {
-            actor->pos.y = params->Y;
+            actor->def.pos.y = params->Y;
             SET_FLAG(THIS->flags, MOVE_ALLOW_H);
             CLR_FLAG(THIS->flags, MOVE_V);
         }
@@ -237,16 +237,16 @@ void vm_actor_move_cancel(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
     UBYTE * n_actor = VM_REF_TO_PTR(idx);
     actor_t * actor = actors + *n_actor;
 
-    actor->movement_interrupt = TRUE;
+    actor->def.movement_interrupt = TRUE;
 }
 
 void vm_actor_activate(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
     UBYTE * n_actor = VM_REF_TO_PTR(idx);
     actor_t * actor = actors + *n_actor;
     if (actor == &PLAYER) {
-        actor->hidden = FALSE;
+        actor->def.hidden = FALSE;
     } else {
-        actor->disabled = FALSE;
+        actor->def.disabled = FALSE;
         activate_actor(actor);
     }
 }
@@ -255,9 +255,9 @@ void vm_actor_deactivate(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
     UBYTE * n_actor = VM_REF_TO_PTR(idx);
     actor_t * actor = actors + *n_actor;
     if (actor == &PLAYER) {
-        actor->hidden = TRUE;
+        actor->def.hidden = TRUE;
     } else {
-        actor->disabled = TRUE;
+        actor->def.disabled = TRUE;
         deactivate_actor(actor);
     }
 }
@@ -268,8 +268,8 @@ void vm_actor_begin_update(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
     act_set_pos_t * params = VM_REF_TO_PTR(idx);
     actor = actors + (UBYTE)(params->ID);
 
-    if ((actor->script_update.bank) && (actor->hscript_update & SCRIPT_TERMINATED)) {
-        script_execute(actor->script_update.bank, actor->script_update.ptr, &(actor->hscript_update), 0);
+    if ((actor->def.script_update.bank) && (actor->hscript_update & SCRIPT_TERMINATED)) {
+        script_execute(actor->def.script_update.bank, actor->def.script_update.ptr, &(actor->hscript_update), 0);
     }
 }
 
@@ -301,8 +301,8 @@ void vm_actor_set_pos(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
     act_set_pos_t * params = VM_REF_TO_PTR(idx);
     actor = actors + (UBYTE)(params->ID);
 
-    actor->pos.x = params->X;
-    actor->pos.y = params->Y;
+    actor->def.pos.x = params->X;
+    actor->def.pos.y = params->Y;
 }
 
 void vm_actor_get_pos(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
@@ -311,8 +311,8 @@ void vm_actor_get_pos(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
     act_set_pos_t * params = VM_REF_TO_PTR(idx);
     actor = actors + (UBYTE)(params->ID);
 
-    params->X = actor->pos.x;
-    params->Y = actor->pos.y;
+    params->X = actor->def.pos.x;
+    params->Y = actor->def.pos.y;
 }
 
 void vm_actor_get_dir(SCRIPT_CTX * THIS, INT16 idx, INT16 dest) OLDCALL BANKED {
@@ -323,7 +323,7 @@ void vm_actor_get_dir(SCRIPT_CTX * THIS, INT16 idx, INT16 dest) OLDCALL BANKED {
     actor = actors + (UBYTE)(params->ID);
 
     if (dest < 0) A = THIS->stack_ptr + dest; else A = script_memory + dest;
-    *A = actor->dir;
+    *A = actor->def.dir;
 }
 
 void vm_actor_get_angle(SCRIPT_CTX * THIS, INT16 idx, INT16 dest) OLDCALL BANKED {
@@ -334,7 +334,7 @@ void vm_actor_get_angle(SCRIPT_CTX * THIS, INT16 idx, INT16 dest) OLDCALL BANKED
     actor = actors + (UBYTE)(params->ID);
 
     if (dest < 0) A = THIS->stack_ptr + dest; else A = script_memory + dest;
-    *A = dir_angle_lookup[actor->dir];
+    *A = dir_angle_lookup[actor->def.dir];
 }
 
 void vm_actor_emote(SCRIPT_CTX * THIS, INT16 idx, UBYTE emote_tiles_bank, const unsigned char *emote_tiles) OLDCALL BANKED {
@@ -362,20 +362,20 @@ void vm_actor_emote(SCRIPT_CTX * THIS, INT16 idx, UBYTE emote_tiles_bank, const 
 void vm_actor_set_bounds(SCRIPT_CTX * THIS, INT16 idx, BYTE left, BYTE right, BYTE top, BYTE bottom) OLDCALL BANKED {
     UBYTE * n_actor = VM_REF_TO_PTR(idx);
     actor_t * actor = actors + *n_actor;
-    actor->bounds.left = left;
-    actor->bounds.right = right;
-    actor->bounds.top = top;
-    actor->bounds.bottom = bottom;
+    actor->def.bounds.left = left;
+    actor->def.bounds.right = right;
+    actor->def.bounds.top = top;
+    actor->def.bounds.bottom = bottom;
 }
 
 void vm_actor_set_spritesheet(SCRIPT_CTX * THIS, INT16 idx, UBYTE spritesheet_bank, const spritesheet_t *spritesheet) OLDCALL BANKED {
     UBYTE * n_actor = VM_REF_TO_PTR(idx);
     actor_t * actor = actors + *n_actor;
     load_sprite(actor->base_tile, spritesheet, spritesheet_bank);
-    actor->sprite.bank = spritesheet_bank;
-    actor->sprite.ptr = (void *)spritesheet;
+    actor->def.sprite.bank = spritesheet_bank;
+    actor->def.sprite.ptr = (void *)spritesheet;
     load_animations(spritesheet, spritesheet_bank, ANIM_SET_DEFAULT, actor->animations);
-    load_bounds(spritesheet, spritesheet_bank, &actor->bounds);
+    load_bounds(spritesheet, spritesheet_bank, &actor->def.bounds);
     actor_reset_anim(actor);
 }
 
@@ -389,14 +389,14 @@ void vm_actor_set_anim_tick(SCRIPT_CTX * THIS, INT16 idx, UBYTE tick) OLDCALL BA
     actor_t *actor;
     UBYTE * n_actor = VM_REF_TO_PTR(idx);
     actor = actors + *n_actor;
-    actor->anim_tick = tick;
+    actor->def.anim_tick = tick;
 }
 
 void vm_actor_set_move_speed(SCRIPT_CTX * THIS, INT16 idx, UBYTE speed) OLDCALL BANKED {
     actor_t *actor;
     UBYTE * n_actor = VM_REF_TO_PTR(idx);
     actor = actors + *n_actor;
-    actor->move_speed = speed;
+    actor->def.move_speed = speed;
 }
 
 void vm_actor_set_anim_frame(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
@@ -421,7 +421,7 @@ void vm_actor_set_anim_set(SCRIPT_CTX * THIS, INT16 idx, UWORD offset) OLDCALL B
     actor_t *actor;
     UBYTE * n_actor = VM_REF_TO_PTR(idx);
     actor = actors + *n_actor;
-    load_animations(actor->sprite.ptr, actor->sprite.bank, offset, actor->animations);
+    load_animations(actor->def.sprite.ptr, actor->def.sprite.bank, offset, actor->animations);
     actor_reset_anim(actor);
 }
 
@@ -435,19 +435,19 @@ void vm_actor_set_spritesheet_by_ref(SCRIPT_CTX * THIS, INT16 idxA, INT16 idxB) 
     const spritesheet_t *spritesheet = params->DATA;
 
     load_sprite(actor->base_tile, spritesheet, spritesheet_bank);
-    actor->sprite.bank = spritesheet_bank;
-    actor->sprite.ptr = (void *)spritesheet;
+    actor->def.sprite.bank = spritesheet_bank;
+    actor->def.sprite.ptr = (void *)spritesheet;
     load_animations(spritesheet, spritesheet_bank, ANIM_SET_DEFAULT, actor->animations);
-    load_bounds(spritesheet, spritesheet_bank, &actor->bounds);
+    load_bounds(spritesheet, spritesheet_bank, &actor->def.bounds);
     actor_reset_anim(actor);
 }
 
 void vm_actor_set_flags(SCRIPT_CTX * THIS, INT16 idx, UBYTE flags, UBYTE mask) OLDCALL BANKED {
     actor_t * actor = actors + *(UBYTE *)VM_REF_TO_PTR(idx);
 
-    if (mask & ACTOR_FLAG_PINNED)      actor->pinned            = (flags & ACTOR_FLAG_PINNED);
-    if (mask & ACTOR_FLAG_HIDDEN)      actor->hidden            = (flags & ACTOR_FLAG_HIDDEN);
-    if (mask & ACTOR_FLAG_ANIM_NOLOOP) actor->anim_noloop       = (flags & ACTOR_FLAG_ANIM_NOLOOP);
-    if (mask & ACTOR_FLAG_COLLISION)   actor->collision_enabled = (flags & ACTOR_FLAG_COLLISION);
-    if (mask & ACTOR_FLAG_PERSISTENT)  actor->persistent        = (flags & ACTOR_FLAG_PERSISTENT);
+    if (mask & ACTOR_FLAG_PINNED)      actor->def.pinned            = (flags & ACTOR_FLAG_PINNED);
+    if (mask & ACTOR_FLAG_HIDDEN)      actor->def.hidden            = (flags & ACTOR_FLAG_HIDDEN);
+    if (mask & ACTOR_FLAG_ANIM_NOLOOP) actor->def.anim_noloop       = (flags & ACTOR_FLAG_ANIM_NOLOOP);
+    if (mask & ACTOR_FLAG_COLLISION)   actor->def.collision_enabled = (flags & ACTOR_FLAG_COLLISION);
+    if (mask & ACTOR_FLAG_PERSISTENT)  actor->def.persistent        = (flags & ACTOR_FLAG_PERSISTENT);
 }

--- a/src/core/vm_scene.c
+++ b/src/core/vm_scene.c
@@ -13,8 +13,8 @@ BANKREF(VM_SCENE)
 
 void vm_scene_push(void) OLDCALL BANKED {
     scene_stack_ptr->scene = current_scene;
-    scene_stack_ptr->pos = PLAYER.pos;
-    scene_stack_ptr->dir = PLAYER.dir;
+    scene_stack_ptr->pos = PLAYER.def.pos;
+    scene_stack_ptr->dir = PLAYER.def.dir;
     scene_stack_ptr++;
 }
 
@@ -23,8 +23,8 @@ static void raise_change_scene_exception(void) {
     vm_exception_params_length = sizeof(far_ptr_t);
     vm_exception_params_bank = 1; // any bank
     vm_exception_params_offset = &scene_stack_ptr->scene;
-    PLAYER.pos = scene_stack_ptr->pos;
-    PLAYER.dir = scene_stack_ptr->dir;
+    PLAYER.def.pos = scene_stack_ptr->pos;
+    PLAYER.def.dir = scene_stack_ptr->dir;
 }
 
 void vm_scene_pop(void) OLDCALL BANKED {

--- a/src/states/adventure.c
+++ b/src/states/adventure.c
@@ -73,59 +73,59 @@ void adventure_update(void) BANKED {
 
     if (player_moving) {
         point16_t new_pos;
-        new_pos.x = PLAYER.pos.x;
-        new_pos.y = PLAYER.pos.y;
+        new_pos.x = PLAYER.def.pos.x;
+        new_pos.y = PLAYER.def.pos.y;
         point_translate_angle(&new_pos, angle, PLAYER.move_speed);
 
         // Step X
-        tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.top);
-        tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom) + 1;
+        tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.top);
+        tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom) + 1;
         if (angle < ANGLE_180DEG) {
-            UBYTE tile_x = PX_TO_TILE(SUBPX_TO_PX(new_pos.x) + PLAYER.bounds.right);
+            UBYTE tile_x = PX_TO_TILE(SUBPX_TO_PX(new_pos.x) + PLAYER.def.bounds.right);
             while (tile_start != tile_end) {
 
                 if (tile_at(tile_x, tile_start) & COLLISION_LEFT) {
-                    new_pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x) - PLAYER.bounds.right) - 1;
+                    new_pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x) - PLAYER.def.bounds.right) - 1;
                     break;
                 }
                 tile_start++;
             }
-            PLAYER.pos.x = MIN(PX_TO_SUBPX(image_width - PLAYER.bounds.right - 1), new_pos.x);
+            PLAYER.def.pos.x = MIN(PX_TO_SUBPX(image_width - PLAYER.def.bounds.right - 1), new_pos.x);
         } else {
-            UBYTE tile_x = PX_TO_TILE(SUBPX_TO_PX(new_pos.x) + PLAYER.bounds.left);
+            UBYTE tile_x = PX_TO_TILE(SUBPX_TO_PX(new_pos.x) + PLAYER.def.bounds.left);
             while (tile_start != tile_end) {
                 if (tile_at(tile_x, tile_start) & COLLISION_RIGHT) {
-                    new_pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x + 1) - PLAYER.bounds.left) + 1;
+                    new_pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x + 1) - PLAYER.def.bounds.left) + 1;
                     break;
                 }
                 tile_start++;
             }
-            PLAYER.pos.x = MAX(0, (WORD)new_pos.x);
+            PLAYER.def.pos.x = MAX(0, (WORD)new_pos.x);
         }
 
         // Step Y
-        tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.left);
-        tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.right) + 1;
+        tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.left);
+        tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.right) + 1;
         if (angle > ANGLE_90DEG && angle < ANGLE_270DEG) {
-            UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(new_pos.y) + PLAYER.bounds.bottom);
+            UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(new_pos.y) + PLAYER.def.bounds.bottom);
             while (tile_start != tile_end) {
                 if (tile_at(tile_start, tile_y) & COLLISION_TOP) {
-                    new_pos.y = PX_TO_SUBPX(TILE_TO_PX(tile_y) - PLAYER.bounds.bottom) - 1;
+                    new_pos.y = PX_TO_SUBPX(TILE_TO_PX(tile_y) - PLAYER.def.bounds.bottom) - 1;
                     break;
                 }
                 tile_start++;
             }
-            PLAYER.pos.y = new_pos.y;
+            PLAYER.def.pos.y = new_pos.y;
         } else {
-            UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(new_pos.y) + PLAYER.bounds.top);
+            UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(new_pos.y) + PLAYER.def.bounds.top);
             while (tile_start != tile_end) {
                 if (tile_at(tile_start, tile_y) & COLLISION_BOTTOM) {
-                    new_pos.y = PX_TO_SUBPX(TILE_TO_PX((UBYTE)(tile_y + 1)) - PLAYER.bounds.top) + 1;
+                    new_pos.y = PX_TO_SUBPX(TILE_TO_PX((UBYTE)(tile_y + 1)) - PLAYER.def.bounds.top) + 1;
                     break;
                 }
                 tile_start++;
             }
-            PLAYER.pos.y = new_pos.y;
+            PLAYER.def.pos.y = new_pos.y;
         }
     }
 
@@ -138,7 +138,7 @@ void adventure_update(void) BANKED {
     hit_actor = NULL;
     if (IS_FRAME_ODD) {
         // Check for trigger collisions
-        if (trigger_activate_at_intersection(&PLAYER.bounds, &PLAYER.pos, FALSE)) {
+        if (trigger_activate_at_intersection(&PLAYER.def.bounds, &PLAYER.def.pos, FALSE)) {
             // Landed on a trigger
             return;
         }

--- a/src/states/platform.c
+++ b/src/states/platform.c
@@ -85,20 +85,20 @@ void platform_init(void) BANKED {
     pl_vel_x = 0;
     pl_vel_y = plat_grav << 2;
 
-    if (PLAYER.dir == DIR_UP || PLAYER.dir == DIR_DOWN) {
-        PLAYER.dir = DIR_RIGHT;
+    if (PLAYER.def.dir == DIR_UP || PLAYER.def.dir == DIR_DOWN) {
+        PLAYER.def.dir = DIR_RIGHT;
     }
 
-    tile_x = SUBPX_TO_TILE(PLAYER.pos.x);
-    tile_y = SUBPX_TO_TILE(PLAYER.pos.y);
+    tile_x = SUBPX_TO_TILE(PLAYER.def.pos.x);
+    tile_y = SUBPX_TO_TILE(PLAYER.def.pos.y);
 
     grounded = FALSE;
 
     // If starting tile was a ladder start scene attached to it
     if (IS_LADDER(tile_at(tile_x, tile_y - 1))) {
         // Snap to ladder
-        UBYTE p_half_width = (PLAYER.bounds.right - PLAYER.bounds.left) >> 1;
-        PLAYER.pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x) + 3 - (PLAYER.bounds.left + p_half_width));
+        UBYTE p_half_width = (PLAYER.def.bounds.right - PLAYER.def.bounds.left) >> 1;
+        PLAYER.def.pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x) + 3 - (PLAYER.def.bounds.left + p_half_width));
         actor_set_anim(&PLAYER, ANIM_CLIMB);
         actor_stop_anim(&PLAYER);
         on_ladder = TRUE;
@@ -118,17 +118,17 @@ void platform_init(void) BANKED {
 void platform_update(void) BANKED {
     UBYTE tile_start, tile_end;
     actor_t *hit_actor;
-    UBYTE p_half_width = (PLAYER.bounds.right - PLAYER.bounds.left) >> 1;
-    UBYTE tile_x_mid = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.left + p_half_width); 
-    UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.top + 1);
+    UBYTE p_half_width = (PLAYER.def.bounds.right - PLAYER.def.bounds.left) >> 1;
+    UBYTE tile_x_mid = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.left + p_half_width); 
+    UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.top + 1);
 
     // Input
     if (on_ladder) {
-        // PLAYER.pos.x = 0;
+        // PLAYER.def.pos.x = 0;
         pl_vel_y = 0;
         if (INPUT_UP) {
             // Climb ladder
-            if(IS_LADDER( tile_at(tile_x_mid, PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom)))) { // Grab with bottom edge
+            if(IS_LADDER( tile_at(tile_x_mid, PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom)))) { // Grab with bottom edge
                 pl_vel_y = -plat_climb_vel;
             }
             else {
@@ -136,15 +136,15 @@ void platform_update(void) BANKED {
             }
         } else if (INPUT_DOWN) {
             // Descend ladder
-            tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom + 1);
+            tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom + 1);
             if (IS_LADDER(tile_at(tile_x_mid, tile_y))) {
                 pl_vel_y = plat_climb_vel;
             }
         } else if (INPUT_LEFT) {
             on_ladder = FALSE;
             // Check if able to leave ladder on left
-            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.top);
-            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom) + 1;
+            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.top);
+            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom) + 1;
             while (tile_start != tile_end) {
                 if (tile_at(tile_x_mid - 1, tile_start) & COLLISION_RIGHT) {
                     on_ladder = TRUE;
@@ -155,8 +155,8 @@ void platform_update(void) BANKED {
         } else if (INPUT_RIGHT) {
             on_ladder = FALSE;
             // Check if able to leave ladder on right
-            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.top);
-            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom) + 1;
+            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.top);
+            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom) + 1;
             while (tile_start != tile_end) {
                 if (tile_at(tile_x_mid + 1, tile_start) & COLLISION_LEFT) {
                     on_ladder = TRUE;
@@ -165,7 +165,7 @@ void platform_update(void) BANKED {
                 tile_start++;
             }
         }
-        PLAYER.pos.y += VEL_TO_SUBPX(pl_vel_y);
+        PLAYER.def.pos.y += VEL_TO_SUBPX(pl_vel_y);
     } else {
         // Horizontal Movement
         if (INPUT_LEFT) {
@@ -202,19 +202,19 @@ void platform_update(void) BANKED {
         // Vertical Movement
         if (INPUT_UP) {
             // Grab upwards ladder
-            tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom); // was top, use feet instead
+            tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom); // was top, use feet instead
             col = tile_at(tile_x_mid, tile_y);
             if (IS_LADDER(col)) {
-                PLAYER.pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x_mid) + 3 - (PLAYER.bounds.left + p_half_width));
+                PLAYER.def.pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x_mid) + 3 - (PLAYER.def.bounds.left + p_half_width));
                 on_ladder = TRUE;
                 pl_vel_x = 0;
             }
         } else if (INPUT_DOWN) {
             // Grab downwards ladder
-            tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom + 1);
+            tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom + 1);
             col = tile_at(tile_x_mid, tile_y);
             if (IS_LADDER(col)) {
-                PLAYER.pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x_mid) + 3 - (PLAYER.bounds.left + p_half_width));
+                PLAYER.def.pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x_mid) + 3 - (PLAYER.def.bounds.left + p_half_width));
                 on_ladder = TRUE;
                 pl_vel_x = 0;
             }
@@ -230,16 +230,16 @@ void platform_update(void) BANKED {
         // Step X
         UBYTE prev_on_slope = on_slope;
         on_slope = FALSE;
-        tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.top);
-        tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom) + 1;
-        UWORD old_x = PLAYER.pos.x;
-        WORD new_x = PLAYER.pos.x + VEL_TO_SUBPX(pl_vel_x);
+        tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.top);
+        tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom) + 1;
+        UWORD old_x = PLAYER.def.pos.x;
+        WORD new_x = PLAYER.def.pos.x + VEL_TO_SUBPX(pl_vel_x);
         UBYTE tile_x = 0;
         UBYTE col_mid = 0;
         if (pl_vel_x > 0) {
-            tile_x = PX_TO_TILE(SUBPX_TO_PX(new_x) + PLAYER.bounds.right);
-            tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom);
-            UBYTE tile_x_mid = PX_TO_TILE(SUBPX_TO_PX(new_x) + PLAYER.bounds.left + p_half_width + 1); 
+            tile_x = PX_TO_TILE(SUBPX_TO_PX(new_x) + PLAYER.def.bounds.right);
+            tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom);
+            UBYTE tile_x_mid = PX_TO_TILE(SUBPX_TO_PX(new_x) + PLAYER.def.bounds.left + p_half_width + 1); 
             col_mid = tile_at(tile_x_mid, tile_y);
             if (IS_ON_SLOPE(col_mid)) {
                 on_slope = col_mid;
@@ -279,24 +279,24 @@ void platform_update(void) BANKED {
                             }
                         }
                     }
-                    new_x = PX_TO_SUBPX(TILE_TO_PX(tile_x) - PLAYER.bounds.right) - 1;
+                    new_x = PX_TO_SUBPX(TILE_TO_PX(tile_x) - PLAYER.def.bounds.right) - 1;
                     pl_vel_x = 0;
                     break;
                 }
                 tile_start++;
             }
-            PLAYER.pos.x = MIN(PX_TO_SUBPX(image_width - PLAYER.bounds.right - 1), new_x);
+            PLAYER.def.pos.x = MIN(PX_TO_SUBPX(image_width - PLAYER.def.bounds.right - 1), new_x);
         } else if (pl_vel_x < 0) {
-            tile_x = PX_TO_TILE(SUBPX_TO_PX(new_x) + PLAYER.bounds.left);
-            tile_y   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom);
-            UBYTE tile_x_mid = PX_TO_TILE(SUBPX_TO_PX(new_x) + PLAYER.bounds.left + p_half_width + 1); 
+            tile_x = PX_TO_TILE(SUBPX_TO_PX(new_x) + PLAYER.def.bounds.left);
+            tile_y   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom);
+            UBYTE tile_x_mid = PX_TO_TILE(SUBPX_TO_PX(new_x) + PLAYER.def.bounds.left + p_half_width + 1); 
             col_mid = tile_at(tile_x_mid, tile_y);
             if (IS_ON_SLOPE(col_mid)) {
                 on_slope = col_mid;
                 slope_y = tile_y;
             }
 
-            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.top);
+            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.top);
             UBYTE slope_on_y = FALSE;
             while (tile_start != tile_end) {
                 col = tile_at(tile_x, tile_start);
@@ -330,31 +330,31 @@ void platform_update(void) BANKED {
                             }
                         }
                     }
-                    new_x = PX_TO_SUBPX(TILE_TO_PX(tile_x + 1) - PLAYER.bounds.left) + 1;
+                    new_x = PX_TO_SUBPX(TILE_TO_PX(tile_x + 1) - PLAYER.def.bounds.left) + 1;
                     pl_vel_x = 0;
                     break;
                 }
                 tile_start++;
             }
-            PLAYER.pos.x = MAX(0, new_x);
+            PLAYER.def.pos.x = MAX(0, new_x);
         }
 
         // Step Y
         UBYTE prev_grounded = grounded;
-        UWORD old_y = PLAYER.pos.y;
+        UWORD old_y = PLAYER.def.pos.y;
         grounded = FALSE;
         // 1 frame leniency of grounded state if we were on a slope last frame
         if (prev_on_slope) grounded = TRUE;
-        tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.left);
-        tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.right) + 1;
+        tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.left);
+        tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.right) + 1;
         if (pl_vel_y > 0) {
-            UWORD new_y = PLAYER.pos.y + VEL_TO_SUBPX(pl_vel_y);
-            tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom) - 1;
-            UBYTE new_tile_y = PX_TO_TILE(SUBPX_TO_PX(new_y) + PLAYER.bounds.bottom);
+            UWORD new_y = PLAYER.def.pos.y + VEL_TO_SUBPX(pl_vel_y);
+            tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom) - 1;
+            UBYTE new_tile_y = PX_TO_TILE(SUBPX_TO_PX(new_y) + PLAYER.def.bounds.bottom);
             // If previously grounded and gravity is not enough to pull us down to the next tile, manually check it for the next slope
             // This prevents the "animation glitch" when going down slopes
             if (prev_grounded && new_tile_y == (tile_y + 1)) new_tile_y += 1;
-            UWORD x_mid_coord = (SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.left + p_half_width + 1);
+            UWORD x_mid_coord = (SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.left + p_half_width + 1);
             while (tile_y <= new_tile_y) {
                 UBYTE col = tile_at(PX_TO_TILE(x_mid_coord), tile_y);
                 UWORD tile_x_coord = TILE_TO_PX(PX_TO_TILE(x_mid_coord));
@@ -362,19 +362,19 @@ void platform_update(void) BANKED {
                 UWORD slope_y_coord = 0;
                 if (IS_ON_SLOPE(col)) {
                     if ((col & COLLISION_SLOPE) == COLLISION_SLOPE_45_RIGHT) {
-                        slope_y_coord = PX_TO_SUBPX(TILE_TO_PX(tile_y) + (8 - x_offset) - PLAYER.bounds.bottom) - 1;
+                        slope_y_coord = PX_TO_SUBPX(TILE_TO_PX(tile_y) + (8 - x_offset) - PLAYER.def.bounds.bottom) - 1;
                     } else if ((col & COLLISION_SLOPE) == COLLISION_SLOPE_225_RIGHT_BOT) {
-                        slope_y_coord = PX_TO_SUBPX(TILE_TO_PX(tile_y) + (8 - (x_offset >> 1)) - PLAYER.bounds.bottom) - 1;
+                        slope_y_coord = PX_TO_SUBPX(TILE_TO_PX(tile_y) + (8 - (x_offset >> 1)) - PLAYER.def.bounds.bottom) - 1;
                     } else if ((col & COLLISION_SLOPE) == COLLISION_SLOPE_225_RIGHT_TOP) {
-                        slope_y_coord = PX_TO_SUBPX(TILE_TO_PX(tile_y) + (4 - (x_offset >> 1)) - PLAYER.bounds.bottom) - 1;
+                        slope_y_coord = PX_TO_SUBPX(TILE_TO_PX(tile_y) + (4 - (x_offset >> 1)) - PLAYER.def.bounds.bottom) - 1;
                     }
 
                     else if ((col & COLLISION_SLOPE) == COLLISION_SLOPE_45_LEFT) {
-                        slope_y_coord = PX_TO_SUBPX(TILE_TO_PX(tile_y) + (x_offset) - PLAYER.bounds.bottom) - 1;
+                        slope_y_coord = PX_TO_SUBPX(TILE_TO_PX(tile_y) + (x_offset) - PLAYER.def.bounds.bottom) - 1;
                     } else if ((col & COLLISION_SLOPE) == COLLISION_SLOPE_225_LEFT_BOT) {
-                        slope_y_coord = PX_TO_SUBPX(TILE_TO_PX(tile_y) + (x_offset >> 1) - PLAYER.bounds.bottom + 4) - 1;
+                        slope_y_coord = PX_TO_SUBPX(TILE_TO_PX(tile_y) + (x_offset >> 1) - PLAYER.def.bounds.bottom + 4) - 1;
                     } else if ((col & COLLISION_SLOPE) == COLLISION_SLOPE_225_LEFT_TOP) {
-                        slope_y_coord = PX_TO_SUBPX(TILE_TO_PX(tile_y) + (x_offset >> 1) - PLAYER.bounds.bottom) - 1;
+                        slope_y_coord = PX_TO_SUBPX(TILE_TO_PX(tile_y) + (x_offset >> 1) - PLAYER.def.bounds.bottom) - 1;
                     }
                 }
 
@@ -385,13 +385,13 @@ void platform_update(void) BANKED {
                         continue;
                     }
                     // If we are moving up a slope, check for top collision
-                    UBYTE slope_top_tile_y = PX_TO_TILE(SUBPX_TO_PX(slope_y_coord) + PLAYER.bounds.top);
+                    UBYTE slope_top_tile_y = PX_TO_TILE(SUBPX_TO_PX(slope_y_coord) + PLAYER.def.bounds.top);
                     while (tile_start != tile_end) {
                         if (tile_at(tile_start, slope_top_tile_y) & COLLISION_BOTTOM) {
                             pl_vel_y = 0;
                             pl_vel_x = 0;
-                            PLAYER.pos.y = old_y;
-                            PLAYER.pos.x = old_x;
+                            PLAYER.def.pos.y = old_y;
+                            PLAYER.def.pos.x = old_x;
                             grounded = TRUE;
                             on_slope = col;
                             slope_y = tile_y;
@@ -400,7 +400,7 @@ void platform_update(void) BANKED {
                         tile_start++;
                     }
 
-                    PLAYER.pos.y = slope_y_coord;
+                    PLAYER.def.pos.y = slope_y_coord;
                     pl_vel_y = 0;
                     grounded = TRUE;
                     on_slope = col;
@@ -410,32 +410,32 @@ void platform_update(void) BANKED {
                 tile_y++;
             }
 
-            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.left);
-            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.right) + 1;
-            tile_y = PX_TO_TILE(SUBPX_TO_PX(new_y) + PLAYER.bounds.bottom);
+            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.left);
+            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.right) + 1;
+            tile_y = PX_TO_TILE(SUBPX_TO_PX(new_y) + PLAYER.def.bounds.bottom);
             while (tile_start != tile_end) {
                 // only snap to the top of a platform if feet are above the line
-                if (tile_at(tile_start, tile_y) & COLLISION_TOP && (SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom - 2) < TILE_TO_PX(tile_y) ) {
-                    new_y = PX_TO_SUBPX(TILE_TO_PX(tile_y) - PLAYER.bounds.bottom) - 1;
+                if (tile_at(tile_start, tile_y) & COLLISION_TOP && (SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom - 2) < TILE_TO_PX(tile_y) ) {
+                    new_y = PX_TO_SUBPX(TILE_TO_PX(tile_y) - PLAYER.def.bounds.bottom) - 1;
                     grounded = TRUE;
                     pl_vel_y = 0;
                     break;
                 }
                 tile_start++;
             }
-            PLAYER.pos.y = new_y;
+            PLAYER.def.pos.y = new_y;
         } else if (pl_vel_y < 0) {
-            UWORD new_y = PLAYER.pos.y + VEL_TO_SUBPX(pl_vel_y);
-            tile_y = PX_TO_TILE(SUBPX_TO_PX(new_y) + PLAYER.bounds.top);
+            UWORD new_y = PLAYER.def.pos.y + VEL_TO_SUBPX(pl_vel_y);
+            tile_y = PX_TO_TILE(SUBPX_TO_PX(new_y) + PLAYER.def.bounds.top);
             while (tile_start != tile_end) {
                 if (tile_at(tile_start, tile_y) & COLLISION_BOTTOM) {
-                    new_y = PX_TO_SUBPX(TILE_TO_PX((UBYTE)(tile_y + 1)) - PLAYER.bounds.top) + 1;
+                    new_y = PX_TO_SUBPX(TILE_TO_PX((UBYTE)(tile_y + 1)) - PLAYER.def.bounds.top) + 1;
                     pl_vel_y = 0;
                     break;
                 }
                 tile_start++;
             }
-            PLAYER.pos.y = new_y;
+            PLAYER.def.pos.y = new_y;
         }
 end_y_collision:
 
@@ -444,7 +444,7 @@ end_y_collision:
     }
 
     // Check for trigger collisions
-    if (trigger_activate_at_intersection(&PLAYER.bounds, &PLAYER.pos, INPUT_UP_PRESSED)) {
+    if (trigger_activate_at_intersection(&PLAYER.def.bounds, &PLAYER.def.pos, INPUT_UP_PRESSED)) {
         // Landed on a trigger
         return;
     }
@@ -452,14 +452,14 @@ end_y_collision:
     // Actor Collisions
     UBYTE can_jump = TRUE;
     hit_actor = actor_overlapping_player(FALSE);
-    if (hit_actor != NULL && hit_actor->collision_group) {
+    if (hit_actor != NULL && hit_actor->def.collision_group) {
         player_register_collision_with(hit_actor);
     } else if (INPUT_PRESSED(INPUT_PLATFORM_INTERACT)) {
         if (!hit_actor) {
             hit_actor = actor_in_front_of_player(8, TRUE);
         }
-        if (hit_actor && !hit_actor->collision_group && hit_actor->script.bank) {
-            script_execute(hit_actor->script.bank, hit_actor->script.ptr, 0, 1, 0);
+        if (hit_actor && !hit_actor->def.collision_group && hit_actor->def.script.bank) {
+            script_execute(hit_actor->def.script.bank, hit_actor->def.script.ptr, 0, 1, 0);
             can_jump = FALSE;
         }
     }
@@ -485,7 +485,7 @@ end_y_collision:
             actor_set_anim_idle(&PLAYER);
         }
     } else {
-        if (PLAYER.dir == DIR_LEFT) {
+        if (PLAYER.def.dir == DIR_LEFT) {
             actor_set_anim(&PLAYER, ANIM_JUMP_LEFT);
         } else {
             actor_set_anim(&PLAYER, ANIM_JUMP_RIGHT);

--- a/src/states/pointnclick.c
+++ b/src/states/pointnclick.c
@@ -22,7 +22,7 @@ void pointnclick_init(void) BANKED {
     camera_offset_y = 0;
     camera_deadzone_x = POINT_N_CLICK_CAMERA_DEADZONE;
     camera_deadzone_y = POINT_N_CLICK_CAMERA_DEADZONE;
-    PLAYER.dir = DIR_RIGHT;
+    PLAYER.def.dir = DIR_RIGHT;
     actor_set_anim(&PLAYER, ANIM_CURSOR);
 }
 
@@ -63,23 +63,23 @@ void pointnclick_update(void) BANKED {
 
     // Move cursor
     if (player_moving) {
-        point_translate_angle(&(PLAYER.pos), angle, PLAYER.move_speed);
+        point_translate_angle(&(PLAYER.def.pos), angle, PLAYER.def.move_speed);
         // Clamp X
-        if (SUBPX_TO_PX(PLAYER.pos.x) - PLAYER.bounds.left > image_width) {
-            PLAYER.pos.x = PX_TO_SUBPX(PLAYER.bounds.left);
-        } else if (SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.right > image_width) {
-            PLAYER.pos.x = PX_TO_SUBPX(image_width - PLAYER.bounds.right);
+        if (SUBPX_TO_PX(PLAYER.def.pos.x) - PLAYER.def.bounds.left > image_width) {
+            PLAYER.def.pos.x = PX_TO_SUBPX(PLAYER.def.bounds.left);
+        } else if (SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.right > image_width) {
+            PLAYER.def.pos.x = PX_TO_SUBPX(image_width - PLAYER.def.bounds.right);
         }
         // Clamp Y
-        if (SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.top > image_height) {
-            PLAYER.pos.y = -PX_TO_SUBPX(PLAYER.bounds.top);
-        } else if (SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom > image_height) {
-            PLAYER.pos.y = PX_TO_SUBPX(image_height - PLAYER.bounds.bottom);
+        if (SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.top > image_height) {
+            PLAYER.def.pos.y = -PX_TO_SUBPX(PLAYER.def.bounds.top);
+        } else if (SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom > image_height) {
+            PLAYER.def.pos.y = PX_TO_SUBPX(image_height - PLAYER.def.bounds.bottom);
         }             
     }
 
     // Check for trigger collisions
-    hit_trigger = trigger_at_intersection(&PLAYER.bounds, &PLAYER.pos);
+    hit_trigger = trigger_at_intersection(&PLAYER.def.bounds, &PLAYER.def.pos);
 
     // Check for actor collisions
     hit_actor = actor_overlapping_player(FALSE);
@@ -87,7 +87,7 @@ void pointnclick_update(void) BANKED {
     is_hover_trigger = (hit_trigger != NO_TRIGGER_COLLISON)
         && (triggers[hit_trigger].script.bank);
 
-    is_hover_actor = hit_actor && hit_actor->script.bank;
+    is_hover_actor = hit_actor && hit_actor->def.script.bank;
 
     // Set cursor animation
     if (is_hover_trigger || is_hover_actor) {
@@ -100,7 +100,7 @@ void pointnclick_update(void) BANKED {
         player_moving = FALSE;
         if (is_hover_actor) {
             // Run actor script
-            script_execute(hit_actor->script.bank, hit_actor->script.ptr, 0, 1, 0);
+            script_execute(hit_actor->def.script.bank, hit_actor->def.script.ptr, 0, 1, 0);
         }
         else if (is_hover_trigger) {
             // Run trigger script

--- a/src/states/shmup.c
+++ b/src/states/shmup.c
@@ -28,7 +28,7 @@ void shmup_init(void) BANKED {
     camera_deadzone_x = 0;
     camera_deadzone_y = 0;
 
-    shooter_direction = PLAYER.dir;
+    shooter_direction = PLAYER.def.dir;
 
     if (shooter_direction == DIR_LEFT) {
         // Right to left scrolling
@@ -80,108 +80,108 @@ void shmup_update(void) BANKED {
     }
 
     // Set animation if direction has changed
-    if (new_dir != PLAYER.dir) {
+    if (new_dir != PLAYER.def.dir) {
         actor_set_dir(&PLAYER, new_dir, player_moving);
     }
 
     // Move player from input
     if (player_moving) {
         point16_t new_pos;
-        new_pos.x = PLAYER.pos.x;
-        new_pos.y = PLAYER.pos.y;
-        point_translate_dir(&new_pos, PLAYER.dir, PLAYER.move_speed);
+        new_pos.x = PLAYER.def.pos.x;
+        new_pos.y = PLAYER.def.pos.y;
+        point_translate_dir(&new_pos, PLAYER.def.dir, PLAYER.def.move_speed);
 
         // Check for tile collisions
         if (IS_DIR_HORIZONTAL(shooter_direction)) {
             // Step Y
-            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.left);
-            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.right) + 1;
-            if (PLAYER.dir == DIR_DOWN) {
-                UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(new_pos.y) + PLAYER.bounds.bottom);
+            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.left);
+            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.right) + 1;
+            if (PLAYER.def.dir == DIR_DOWN) {
+                UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(new_pos.y) + PLAYER.def.bounds.bottom);
                 while (tile_start != tile_end) {
                     if (tile_at(tile_start, tile_y) & COLLISION_TOP) {
-                        new_pos.y = PX_TO_SUBPX(TILE_TO_PX(tile_y) - PLAYER.bounds.bottom) - 1;
+                        new_pos.y = PX_TO_SUBPX(TILE_TO_PX(tile_y) - PLAYER.def.bounds.bottom) - 1;
                         break;
                     }
                     tile_start++;
                 }
-                PLAYER.pos.y = new_pos.y;
+                PLAYER.def.pos.y = new_pos.y;
             } else {
-                UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(new_pos.y) + PLAYER.bounds.top);
+                UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(new_pos.y) + PLAYER.def.bounds.top);
                 while (tile_start != tile_end) {
                     if (tile_at(tile_start, tile_y) & COLLISION_BOTTOM) {
-                        new_pos.y = PX_TO_SUBPX(TILE_TO_PX((UBYTE)(tile_y + 1)) - PLAYER.bounds.top) + 1;
+                        new_pos.y = PX_TO_SUBPX(TILE_TO_PX((UBYTE)(tile_y + 1)) - PLAYER.def.bounds.top) + 1;
                         break;
                     }
                     tile_start++;
                 }
-                PLAYER.pos.y = new_pos.y;
+                PLAYER.def.pos.y = new_pos.y;
             }
         } else {
             // Step X
-            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.top);
-            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom) + 1;
-            if (PLAYER.dir == DIR_RIGHT) {
-                UBYTE tile_x = PX_TO_TILE(SUBPX_TO_PX(new_pos.x) + PLAYER.bounds.right);
+            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.top);
+            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom) + 1;
+            if (PLAYER.def.dir == DIR_RIGHT) {
+                UBYTE tile_x = PX_TO_TILE(SUBPX_TO_PX(new_pos.x) + PLAYER.def.bounds.right);
                 while (tile_start != tile_end) {
                     if (tile_at(tile_x, tile_start) & COLLISION_LEFT) {
-                        new_pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x) - PLAYER.bounds.right) - 1;           
+                        new_pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x) - PLAYER.def.bounds.right) - 1;           
                         break;
                     }
                     tile_start++;
                 }
-                PLAYER.pos.x = MIN(PX_TO_SUBPX(image_width - PLAYER.bounds.right - 1), new_pos.x);
+                PLAYER.def.pos.x = MIN(PX_TO_SUBPX(image_width - PLAYER.def.bounds.right - 1), new_pos.x);
             } else {
-                UBYTE tile_x = PX_TO_TILE(SUBPX_TO_PX(new_pos.x) + PLAYER.bounds.left);
+                UBYTE tile_x = PX_TO_TILE(SUBPX_TO_PX(new_pos.x) + PLAYER.def.bounds.left);
                 while (tile_start != tile_end) {
                     if (tile_at(tile_x, tile_start) & COLLISION_RIGHT) {
-                        new_pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x + 1) - PLAYER.bounds.left) + 1;         
+                        new_pos.x = PX_TO_SUBPX(TILE_TO_PX(tile_x + 1) - PLAYER.def.bounds.left) + 1;         
                         break;
                     }
                     tile_start++;
                 }
-                PLAYER.pos.x = MAX(0, (WORD)new_pos.x);
+                PLAYER.def.pos.x = MAX(0, (WORD)new_pos.x);
             }
         }
     }
 
     // Auto scroll background
     if (!shooter_reached_end) {
-        point_translate_dir(&PLAYER.pos, shooter_direction, shooter_scroll_speed);
+        point_translate_dir(&PLAYER.def.pos, shooter_direction, shooter_scroll_speed);
 
         // Check if reached end of screen
-        if ((shooter_direction == DIR_RIGHT) && (PLAYER.pos.x > shooter_dest)) {
+        if ((shooter_direction == DIR_RIGHT) && (PLAYER.def.pos.x > shooter_dest)) {
             shooter_reached_end = TRUE;
-            PLAYER.pos.x = shooter_dest;
-        } else if ((shooter_direction == DIR_LEFT) && (PLAYER.pos.x < shooter_dest)) {
+            PLAYER.def.pos.x = shooter_dest;
+        } else if ((shooter_direction == DIR_LEFT) && (PLAYER.def.pos.x < shooter_dest)) {
             shooter_reached_end = TRUE;
-            PLAYER.pos.x = shooter_dest;
-        } else if ((shooter_direction == DIR_DOWN) && (PLAYER.pos.y > shooter_dest)) {
+            PLAYER.def.pos.x = shooter_dest;
+        } else if ((shooter_direction == DIR_DOWN) && (PLAYER.def.pos.y > shooter_dest)) {
             shooter_reached_end = TRUE;
-            PLAYER.pos.y = shooter_dest;
-        } else if ((shooter_direction == DIR_UP) && (PLAYER.pos.y < shooter_dest)) {
+            PLAYER.def.pos.y = shooter_dest;
+        } else if ((shooter_direction == DIR_UP) && (PLAYER.def.pos.y < shooter_dest)) {
             shooter_reached_end = TRUE;
-            PLAYER.pos.y = shooter_dest;
+            PLAYER.def.pos.y = shooter_dest;
         }
     }
 
     if (IS_FRAME_ODD) {
         // Check for trigger collisions
-        if (trigger_activate_at_intersection(&PLAYER.bounds, &PLAYER.pos, FALSE)) {
+        if (trigger_activate_at_intersection(&PLAYER.def.bounds, &PLAYER.def.pos, FALSE)) {
             // Landed on a trigger
             return;
         }
 
         // Check for actor collisions
         hit_actor = actor_overlapping_player(FALSE);
-        if (hit_actor != NULL && hit_actor->collision_group) {
+        if (hit_actor != NULL && hit_actor->def.collision_group) {
             player_register_collision_with(hit_actor);
         } else if (INPUT_A_PRESSED) {
             if (!hit_actor) {
                 hit_actor = actor_in_front_of_player(8, TRUE);
             }
-            if (hit_actor && !hit_actor->collision_group && hit_actor->script.bank) {
-                script_execute(hit_actor->script.bank, hit_actor->script.ptr, 0, 1, 0);
+            if (hit_actor && !hit_actor->def.collision_group && hit_actor->def.script.bank) {
+                script_execute(hit_actor->def.script.bank, hit_actor->def.script.ptr, 0, 1, 0);
             }
         }
     }

--- a/src/states/topdown.c
+++ b/src/states/topdown.c
@@ -27,11 +27,11 @@ void topdown_init(void) BANKED {
 
     if (topdown_grid == 16) {
         // Snap to 16px grid
-        PLAYER.pos.x = SUBPX_SNAP_TILE16(PLAYER.pos.x);
-        PLAYER.pos.y = SUBPX_SNAP_TILE16(PLAYER.pos.y) + TILE_TO_SUBPX(1);
+        PLAYER.def.pos.x = SUBPX_SNAP_TILE16(PLAYER.def.pos.x);
+        PLAYER.def.pos.y = SUBPX_SNAP_TILE16(PLAYER.def.pos.y) + TILE_TO_SUBPX(1);
     } else {
-        PLAYER.pos.x = SUBPX_SNAP_TILE(PLAYER.pos.x);
-        PLAYER.pos.y = SUBPX_SNAP_TILE(PLAYER.pos.y);
+        PLAYER.def.pos.x = SUBPX_SNAP_TILE(PLAYER.def.pos.x);
+        PLAYER.def.pos.y = SUBPX_SNAP_TILE(PLAYER.def.pos.y);
     }
 }
 
@@ -41,14 +41,14 @@ void topdown_update(void) BANKED {
     direction_e new_dir = DIR_NONE;
 
     // Is player on an 8x8px tile?
-    if ((topdown_grid == 16 && ON_16PX_GRID(PLAYER.pos)) ||
-        (topdown_grid == 8 && ON_8PX_GRID(PLAYER.pos))) {
+    if ((topdown_grid == 16 && ON_16PX_GRID(PLAYER.def.pos)) ||
+        (topdown_grid == 8 && ON_8PX_GRID(PLAYER.def.pos))) {
         // Player landed on an tile
         // so stop movement for now
         player_moving = FALSE;
 
         // Check for trigger collisions
-        if (trigger_activate_at_intersection(&PLAYER.bounds, &PLAYER.pos, FALSE)) {
+        if (trigger_activate_at_intersection(&PLAYER.def.bounds, &PLAYER.def.pos, FALSE)) {
             // Landed on a trigger
             return;
         }
@@ -59,9 +59,9 @@ void topdown_update(void) BANKED {
             new_dir = DIR_LEFT;
 
             // Check for collisions to left of player
-            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.top);
-            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom) + 1;
-            UBYTE tile_x = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.left);
+            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.top);
+            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom) + 1;
+            UBYTE tile_x = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.left);
             while (tile_start != tile_end) {
                 if (tile_at(tile_x - 1, tile_start) & COLLISION_RIGHT) {
                     player_moving = FALSE;
@@ -74,9 +74,9 @@ void topdown_update(void) BANKED {
             new_dir = DIR_RIGHT;
 
             // Check for collisions to right of player
-            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.top);
-            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom) + 1;
-            UBYTE tile_x = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.right);
+            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.top);
+            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom) + 1;
+            UBYTE tile_x = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.right);
             while (tile_start != tile_end) {
                 if (tile_at(tile_x + 1, tile_start) & COLLISION_LEFT) {
                     player_moving = FALSE;
@@ -89,9 +89,9 @@ void topdown_update(void) BANKED {
             new_dir = DIR_UP;
 
             // Check for collisions below player
-            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.left);
-            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.right) + 1;
-            UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.top);
+            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.left);
+            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.right) + 1;
+            UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.top);
             while (tile_start != tile_end) {
                 if (tile_at(tile_start, tile_y - 1) & COLLISION_BOTTOM) {
                     player_moving = FALSE;
@@ -104,9 +104,9 @@ void topdown_update(void) BANKED {
             new_dir = DIR_DOWN;
 
             // Check for collisions below player
-            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.left);
-            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.x) + PLAYER.bounds.right) + 1;
-            UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.pos.y) + PLAYER.bounds.bottom);
+            tile_start = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.left);
+            tile_end   = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.x) + PLAYER.def.bounds.right) + 1;
+            UBYTE tile_y = PX_TO_TILE(SUBPX_TO_PX(PLAYER.def.pos.y) + PLAYER.def.bounds.bottom);
             while (tile_start != tile_end) {
                 if (tile_at(tile_start, tile_y + 1) & COLLISION_TOP) {
                     player_moving = FALSE;
@@ -126,7 +126,7 @@ void topdown_update(void) BANKED {
         if (IS_FRAME_ODD) {
             // Check for actor overlap
             hit_actor = actor_overlapping_player(FALSE);
-            if (hit_actor != NULL && hit_actor->collision_group) {
+            if (hit_actor != NULL && hit_actor->def.collision_group) {
                 player_register_collision_with(hit_actor);
             }
         }
@@ -143,15 +143,15 @@ void topdown_update(void) BANKED {
 
         if (INPUT_PRESSED(INPUT_TOPDOWN_INTERACT)) {
             hit_actor = actor_in_front_of_player(topdown_grid, TRUE);
-            if (hit_actor != NULL && !hit_actor->collision_group) {
-                actor_set_dir(hit_actor, FLIPPED_DIR(PLAYER.dir), FALSE);
+            if (hit_actor != NULL && !hit_actor->def.collision_group) {
+                actor_set_dir(hit_actor, FLIPPED_DIR(PLAYER.def.dir), FALSE);
                 player_moving = FALSE;
-                if (hit_actor->script.bank) {
-                    script_execute(hit_actor->script.bank, hit_actor->script.ptr, 0, 1, 0);
+                if (hit_actor->def.script.bank) {
+                    script_execute(hit_actor->def.script.bank, hit_actor->def.script.ptr, 0, 1, 0);
                 }
             }
         }
     }
 
-    if (player_moving) point_translate_dir(&PLAYER.pos, PLAYER.dir, PLAYER.move_speed);
+    if (player_moving) point_translate_dir(&PLAYER.def.pos, PLAYER.def.dir, PLAYER.def.move_speed);
 }


### PR DESCRIPTION
- Make the actor_def_t struct be a member of actor_t, making it consistent with projectile_def_t / projectile_t

- Remove load_actor_from_def function in favor of simple memset + memcpy to initialize an actor_t