### PR TITLE
Normalize tabulations and remove trailing white spaces

### DIFF
--- a/include/collision.h
+++ b/include/collision.h
@@ -30,9 +30,9 @@ extern UBYTE tile_hit_y;
  * @return Point is within bounding box
  */
 inline UBYTE bb_contains(rect16_t *bb, upoint16_t *offset, upoint16_t *point) {
-    if ((point->x < offset->x + bb->left) || 
+    if ((point->x < offset->x + bb->left) ||
         (point->x > offset->x + bb->right)) return FALSE;
-    if ((point->y < offset->y + bb->top) || 
+    if ((point->y < offset->y + bb->top) ||
         (point->y > offset->y + bb->bottom)) return FALSE;
     return TRUE;
 }
@@ -48,7 +48,7 @@ inline UBYTE bb_contains(rect16_t *bb, upoint16_t *offset, upoint16_t *point) {
  */
 inline UBYTE bb_intersects(rect16_t *bb_a, upoint16_t *offset_a, rect16_t *bb_b, upoint16_t *offset_b) {
     if ((offset_b->x + bb_b->left   > offset_a->x + bb_a->right) ||
-        (offset_b->x + bb_b->right  < offset_a->x + bb_a->left)) return FALSE;    
+        (offset_b->x + bb_b->right  < offset_a->x + bb_a->left)) return FALSE;
     if ((offset_b->y + bb_b->top    > offset_a->y + bb_a->bottom) ||
         (offset_b->y + bb_b->bottom < offset_a->y + bb_a->top)) return FALSE;
     return TRUE;
@@ -62,7 +62,7 @@ inline UBYTE bb_intersects(rect16_t *bb_a, upoint16_t *offset_a, rect16_t *bb_b,
  * @return Tile value, 0 if no collisions, COLLISION_ALL if out of bounds
  */
 inline UBYTE tile_at(UBYTE tx, UBYTE ty) {
-    if ((tx < image_tile_width) && (ty < image_tile_height)) 
+    if ((tx < image_tile_width) && (ty < image_tile_height))
         return ReadBankedUBYTE(collision_ptr + (ty * (UINT16)image_tile_width) + tx, collision_bank);
     return COLLISION_ALL;
 }
@@ -70,7 +70,7 @@ inline UBYTE tile_at(UBYTE tx, UBYTE ty) {
 /**
  * Test for a tile matching mask in a vertical range from ty_start to ty_end at column tx.
  * Updates globals tile_hit_x and tile_hit_y which can be read afterwards to determine which tile matched
- * 
+ *
  * @param tile_mask Tile bitmask to match
  * @param tx Tile x-coordinate
  * @param ty_start Starting tile y-coordinate

--- a/include/events.h
+++ b/include/events.h
@@ -10,7 +10,7 @@ typedef struct script_event_t {
 } script_event_t;
 
 extern script_event_t input_events[8];
-extern UBYTE input_slots[8]; 
+extern UBYTE input_slots[8];
 
 typedef struct timer_time_t {
     UBYTE value, remains;

--- a/include/hUGEDriver.h
+++ b/include/hUGEDriver.h
@@ -136,7 +136,7 @@ extern volatile unsigned char hUGE_current_wave;
 extern volatile unsigned char hUGE_mute_mask;
 
 inline void hUGE_reset_wave(void) {
-	hUGE_current_wave = 100;
+    hUGE_current_wave = 100;
 }
 
 #endif

--- a/include/macro.h
+++ b/include/macro.h
@@ -2,9 +2,9 @@
 #define MACRO_H
 
 // Bit Flags Helpers
-#define SET_FLAG(n, f) ((n) |= (f)) 
-#define CLR_FLAG(n, f) ((n) &= ~(f)) 
-#define TGL_FLAG(n, f) ((n) ^= (f)) 
+#define SET_FLAG(n, f) ((n) |= (f))
+#define CLR_FLAG(n, f) ((n) &= ~(f))
+#define TGL_FLAG(n, f) ((n) ^= (f))
 #define CHK_FLAG(n, f) ((n) & (f))
 
 #endif

--- a/include/rtc.h
+++ b/include/rtc.h
@@ -15,7 +15,7 @@ typedef enum {
     RTC_VALUE_SEC = 0x08,
     RTC_VALUE_MIN,
     RTC_VALUE_HOUR,
-    RTC_VALUE_DAY 
+    RTC_VALUE_DAY
 } rtc_dateparts_e;
 
 #define RTC_VALUE_FLAGS 0x0c
@@ -39,7 +39,7 @@ inline void RTC_SET(const rtc_dateparts_e part, const UWORD v) {
     RTC_VALUE_REG = v;
     if (part == RTC_VALUE_DAY) {
         RTC_SELECT(RTC_VALUE_FLAGS);
-        RTC_VALUE_REG = (RTC_VALUE_REG & 0x0e) | (UBYTE)((v >> 8) & 0x01);     
+        RTC_VALUE_REG = (RTC_VALUE_REG & 0x0e) | (UBYTE)((v >> 8) & 0x01);
     }
 }
 

--- a/include/scroll.h
+++ b/include/scroll.h
@@ -46,7 +46,7 @@ void scroll_init(void) BANKED;
 void scroll_update(void) BANKED;
 
 /**
- * Resets scroll and update the whole screen 
+ * Resets scroll and update the whole screen
  */
 void scroll_repaint(void) BANKED;
 
@@ -65,7 +65,7 @@ UINT8 * GetBkgAddr(void) OLDCALL PRESERVES_REGS(b, c, h, l);
  * @param base_addr address of top-left corner
  * @param w width of the area
  * @param h height of the area
- * @param fill tile id to fill the bottom row 
+ * @param fill tile id to fill the bottom row
  */
 void scroll_rect(UBYTE * base_addr, UBYTE w, UBYTE h, UBYTE fill) OLDCALL BANKED PRESERVES_REGS(b, c);
 

--- a/include/shadow.h
+++ b/include/shadow.h
@@ -6,9 +6,9 @@
 extern volatile OAM_item_t shadow_OAM2[40];
 
 inline void toggle_shadow_OAM(void) {
-    if (_shadow_OAM_base == (UBYTE)((UWORD)&shadow_OAM >> 8)) { 
-        __render_shadow_OAM = (UBYTE)((UWORD)&shadow_OAM2 >> 8); 
-    } else { 
+    if (_shadow_OAM_base == (UBYTE)((UWORD)&shadow_OAM >> 8)) {
+        __render_shadow_OAM = (UBYTE)((UWORD)&shadow_OAM2 >> 8);
+    } else {
         __render_shadow_OAM = (UBYTE)((UWORD)&shadow_OAM >> 8);
     }
     allocated_hardware_sprites = 0;

--- a/include/sincos.h
+++ b/include/sincos.h
@@ -24,7 +24,7 @@ static const int8_t sine_wave[256] = {
     -49, -46,  -43, -40, -37, -34, -31, -28, -25, -22, -19, -16, -12,  -9,  -6,  -3
 };
 
-inline int8_t SIN(uint8_t A) { 
+inline int8_t SIN(uint8_t A) {
     return sine_wave[A];
 }
 inline int8_t COS(uint8_t A) {

--- a/include/system.h
+++ b/include/system.h
@@ -7,12 +7,12 @@
 extern UBYTE _is_CGB;
 extern UBYTE _is_SGB;
 
-// SRAM bank switching with saving of state 
+// SRAM bank switching with saving of state
 extern volatile UBYTE _current_ram_bank;
 
 #define RAM_BANKS_ONLY 0x0fu
 #define RAM_BANKS_AND_FLAGS 0xffu
 
-inline void SWITCH_RAM_BANK(UBYTE bank, UBYTE mask) { SWITCH_RAM(_current_ram_bank = ((_current_ram_bank & ~mask) | (bank & mask))); } 
+inline void SWITCH_RAM_BANK(UBYTE bank, UBYTE mask) { SWITCH_RAM(_current_ram_bank = ((_current_ram_bank & ~mask) | (bank & mask))); }
 
 #endif

--- a/include/vm.i
+++ b/include/vm.i
@@ -4,8 +4,8 @@
 ;      order: left-to-right (leftmost argument pushed first)
 
 ; exception ID's
-EXCEPTION_RESET            = 1
-EXCEPTION_CHANGE_SCENE    = 2
+EXCEPTION_RESET         = 1
+EXCEPTION_CHANGE_SCENE  = 2
 EXCEPTION_SAVE          = 3
 EXCEPTION_LOAD          = 4
 

--- a/include/vm.i
+++ b/include/vm.i
@@ -4,8 +4,8 @@
 ;      order: left-to-right (leftmost argument pushed first)
 
 ; exception ID's
-EXCEPTION_RESET	        = 1
-EXCEPTION_CHANGE_SCENE	= 2
+EXCEPTION_RESET            = 1
+EXCEPTION_CHANGE_SCENE    = 2
 EXCEPTION_SAVE          = 3
 EXCEPTION_LOAD          = 4
 

--- a/include/vm_gameboy.h
+++ b/include/vm_gameboy.h
@@ -37,7 +37,7 @@ void vm_replace_tile_xy(SCRIPT_CTX * THIS, UBYTE x, UBYTE y, UBYTE tileset_bank,
 
 #ifndef RUMBLE_ENABLE
 #define RUMBLE_ENABLE 0x20u
-#endif 
+#endif
 void vm_rumble(SCRIPT_CTX * THIS, UBYTE enable) OLDCALL BANKED;
 
 void vm_load_tileset(SCRIPT_CTX * THIS, INT16 idx, UBYTE bank, const background_t * background) OLDCALL BANKED;

--- a/src/core/absolute.c
+++ b/src/core/absolute.c
@@ -4,7 +4,7 @@
 #define SHADOW_OAM_PAGE_WITH_GAP SHADOW_OAM2_BASE_ADDRESS
 
 // Note: if we move SHADOW_OAM2_BASE_ADDRESS to 0xC100 then SHADOW_OAM_PAGE_WITH_GAP will be 0xC000
-//       to do that, in the build scripts the base address of _DATA should be set to 0xC1A0 and 
+//       to do that, in the build scripts the base address of _DATA should be set to 0xC1A0 and
 //       .STACK should be set to 0xE000 (default value)
 
 #define add_check__(a,b) add_check___(a,b)

--- a/src/core/actor.c
+++ b/src/core/actor.c
@@ -37,7 +37,7 @@ BANKREF(ACTOR)
 const BYTE emote_offsets[] = {2, 1, 0, -1, -2, -3, -4, -5, -6, -5, -4, -3, -2, -1, 0};
 
 const metasprite_t emote_metasprite_8_16[]  = {
-    {8, 8, 0, 7}, {0, 8, 2, 7}, 
+    {8, 8, 0, 7}, {0, 8, 2, 7},
     {metasprite_end}
 };
 
@@ -85,7 +85,7 @@ void actors_update(void) BANKED {
     actor_t *actor;
     static uint8_t screen_tile16_x, screen_tile16_y, screen_tile16_x_end, screen_tile16_y_end;
     static uint8_t actor_tile16_x, actor_tile16_y;
-    static uint8_t tmp_iterator; 
+    static uint8_t tmp_iterator;
     static FASTUBYTE actor_flags;
 
     // Convert scroll pos to 16px tile coordinates
@@ -147,7 +147,7 @@ void actors_update(void) BANKED {
                     } else {
                         if (CHK_FLAG(actor_flags, ACTOR_FLAG_DISABLED)) {
                             CLR_FLAG(actor->flags, ACTOR_FLAG_DISABLED);
-                        }                        
+                        }
                         deactivate_actor_impl(actor);
                     }
                 } else {
@@ -212,7 +212,7 @@ void actors_render(void) NONBANKED {
         if (!(window_hide_actors && (screen_x + 8 > WX_REG) && (screen_y - 8 > WY_REG))) {
             SWITCH_ROM(PLAYER.sprite.bank);
             spritesheet_t *sprite = PLAYER.sprite.ptr;
-    
+
             allocated_hardware_sprites += move_metasprite(
                 *(sprite->metasprites + PLAYER.frame),
                 PLAYER.base_tile,
@@ -222,13 +222,13 @@ void actors_render(void) NONBANKED {
             );
         }
     }
-    
+
     // Render all actors
     for (actor = PLAYER.prev; (actor); actor = actor->prev){
         if (CHK_FLAG(actor->flags, ACTOR_FLAG_HIDDEN | ACTOR_FLAG_DISABLED)) {
            continue;
         }
-        
+
         if (CHK_FLAG(actor->flags, ACTOR_FLAG_PINNED)) {
             screen_x = SUBPX_TO_PX(actor->pos.x);
             screen_y = SUBPX_TO_PX(actor->pos.y);
@@ -322,7 +322,7 @@ static void activate_actor_impl(actor_t *actor) {
                 SET_FLAG(actor->flags, ACTOR_FLAG_DISABLED);
             } else {
                 return;
-            } 
+            }
         }
     }
 

--- a/src/core/bankdata.c
+++ b/src/core/bankdata.c
@@ -13,9 +13,9 @@ __asm
     ldh a, (__current_bank)
     ldh (#__save), a
 
-    ldhl  sp,    #6
+    ldhl  sp, #6
     ld  a, (hl)
-    ldh    (__current_bank), a
+    ldh (__current_bank), a
     ld  (_rROMB0), a
 
     pop bc
@@ -38,7 +38,7 @@ __asm
 
     ldhl  sp, #6
     ld  a, (hl)
-    ldh    (__current_bank), a
+    ldh (__current_bank), a
     ld  (_rROMB0), a
 
     pop bc
@@ -61,7 +61,7 @@ __asm
 
     ldhl  sp, #8
     ld  a, (hl)
-    ldh    (__current_bank), a
+    ldh (__current_bank), a
     ld  (_rROMB0), a
 
     pop bc
@@ -84,7 +84,7 @@ __asm
 
     ldhl  sp, #8
     ld  a, (hl)
-    ldh    (__current_bank), a
+    ldh (__current_bank), a
     ld  (_rROMB0), a
 
     pop bc
@@ -107,7 +107,7 @@ __asm
 
     ldhl sp, #2
     ld  a, (hl)
-    ldh    (__current_bank), a
+    ldh (__current_bank), a
     ld  (_rROMB0), a
 
     ld h, b
@@ -139,7 +139,7 @@ __asm
     ldh (#__save), a
 
     ld  a, c
-    ldh    (__current_bank), a
+    ldh (__current_bank), a
     ld  (_rROMB0), a
 
     ld h, d

--- a/src/core/bankdata.c
+++ b/src/core/bankdata.c
@@ -13,9 +13,9 @@ __asm
     ldh a, (__current_bank)
     ldh (#__save), a
 
-    ldhl  sp,	#6
+    ldhl  sp,    #6
     ld  a, (hl)
-    ldh	(__current_bank), a
+    ldh    (__current_bank), a
     ld  (_rROMB0), a
 
     pop bc
@@ -38,7 +38,7 @@ __asm
 
     ldhl  sp, #6
     ld  a, (hl)
-    ldh	(__current_bank), a
+    ldh    (__current_bank), a
     ld  (_rROMB0), a
 
     pop bc
@@ -61,7 +61,7 @@ __asm
 
     ldhl  sp, #8
     ld  a, (hl)
-    ldh	(__current_bank), a
+    ldh    (__current_bank), a
     ld  (_rROMB0), a
 
     pop bc
@@ -84,7 +84,7 @@ __asm
 
     ldhl  sp, #8
     ld  a, (hl)
-    ldh	(__current_bank), a
+    ldh    (__current_bank), a
     ld  (_rROMB0), a
 
     pop bc
@@ -107,7 +107,7 @@ __asm
 
     ldhl sp, #2
     ld  a, (hl)
-    ldh	(__current_bank), a
+    ldh    (__current_bank), a
     ld  (_rROMB0), a
 
     ld h, b
@@ -139,7 +139,7 @@ __asm
     ldh (#__save), a
 
     ld  a, c
-    ldh	(__current_bank), a
+    ldh    (__current_bank), a
     ld  (_rROMB0), a
 
     ld h, d

--- a/src/core/bootstrap.s
+++ b/src/core/bootstrap.s
@@ -1,6 +1,6 @@
 .include "vm.i"
 .include "macro.i"
-        
+
 .area _CODE_255
 
 ___bank_bootstrap_script = 255

--- a/src/core/collision.c
+++ b/src/core/collision.c
@@ -73,7 +73,7 @@ UBYTE tile_col_test_range_x(UBYTE tile_mask, UBYTE ty, UBYTE tx_start, UBYTE tx_
         if (tile_hit_x >= image_tile_width) {
           SWITCH_ROM(_save);
           return COLLISION_ALL & tile_mask ? COLLISION_ALL : 0;
-        }                
+        }
     }
     SWITCH_ROM(_save);
     return 0;

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -37,7 +37,7 @@
 extern void __bank_bootstrap_script;
 extern const UBYTE bootstrap_script[];
 
-extern void core_reset_hook(void); 
+extern void core_reset_hook(void);
 
 UBYTE pause_state_update;
 
@@ -62,12 +62,12 @@ void process_VM(void) {
     while (TRUE) {
         switch (script_runner_update()) {
             case RUNNER_DONE:
-            case RUNNER_IDLE: {                
+            case RUNNER_IDLE: {
                 input_update();
                 if (INPUT_SOFT_RESTART) {
-                    // kill all threads and clear VM memory 
+                    // kill all threads and clear VM memory
                     script_runner_init(TRUE);
-                    // execute bootstrap script              
+                    // execute bootstrap script
                     script_execute(BANK(bootstrap_script), bootstrap_script, 0, 0);
                     break;
                 }
@@ -78,7 +78,7 @@ void process_VM(void) {
                     music_events_update();                              // update music events
                 }
 
-                toggle_shadow_OAM();                
+                toggle_shadow_OAM();
 
                 camera_update();
                 scroll_update();
@@ -118,7 +118,7 @@ void process_VM(void) {
                     case EXCEPTION_CHANGE_SCENE: {
                         // remove previous LCD ISR's
                         remove_LCD_ISRs();
-                        // kill all threads, but don't clear variables 
+                        // kill all threads, but don't clear variables
                         script_runner_init(FALSE);
                         // reset timers on scene change
                         timers_init(FALSE);
@@ -154,7 +154,7 @@ void process_VM(void) {
 
                 CRITICAL {
                     switch (scene_LCD_type) {
-                        case LCD_parallax: 
+                        case LCD_parallax:
                             add_LCD(parallax_LCD_isr);
                             break;
                         case LCD_fullscreen:
@@ -166,10 +166,10 @@ void process_VM(void) {
                     }
                     LYC_REG = 0u;
                 }
-                if (!hide_sprites) SHOW_SPRITES;    // show sprites back if we switched LCD ISR while sprites were hidden 
+                if (!hide_sprites) SHOW_SPRITES;    // show sprites back if we switched LCD ISR while sprites were hidden
 
                 pause_state_update = false;
-                
+
                 player_init();
                 state_init();
                 toggle_shadow_OAM();
@@ -192,7 +192,7 @@ void core_run(void) BANKED {
     for (UBYTE i = 4; i != 0; i--) wait_vbl_done(); // this delay is required for PAL SNES
     _is_SGB = sgb_check();
     if (_is_SGB) set_sgb_border(SGB_border_chr, SIZE(SGB_border_chr), BANK(SGB_border_chr),
-                                SGB_border_map, SIZE(SGB_border_map), BANK(SGB_border_map), 
+                                SGB_border_map, SIZE(SGB_border_map), BANK(SGB_border_map),
                                 SGB_border_pal, SIZE(SGB_border_pal), BANK(SGB_border_pal));
     // both CGB + SGB modes at once are not supported
     _is_CGB = ((!_is_SGB) && (_cpu == CGB_TYPE) && (*(UBYTE *)0x0143 & 0x80));
@@ -231,7 +231,7 @@ void core_run(void) BANKED {
         LYC_REG = 0u;
 
         add_VBL(VBL_isr);
-        STAT_REG |= STATF_LYC; 
+        STAT_REG |= STATF_LYC;
 
         music_setup_timer();
         IE_REG |= (TIM_IFLAG | LCD_IFLAG | SIO_IFLAG);

--- a/src/core/crash_handler.s
+++ b/src/core/crash_handler.s
@@ -35,8 +35,8 @@ ___HandleCrash::
         ld      (wCrashA), a
         ld      a, #b___HandleCrash_banked
         ld      (rROMB0), a
-        ld      a, (wCrashA) 
-        jp      ___HandleCrash_banked 
+        ld      a, (wCrashA)
+        jp      ___HandleCrash_banked
 
 
         .area   _CODE_255
@@ -335,7 +335,7 @@ ___HandleCrash_banked::
         ret
 
 loadfont:
-        ld      hl, #.font_data 
+        ld      hl, #.font_data
 4$:
         ld      a, (hl+)
         ld      e, a
@@ -370,16 +370,16 @@ loadfont:
         dec     c
         jr      NZ, 5$
         jr      1$
-        
-.font_data:      
+
+.font_data:
         .dw     #0x9000
         .db     #-8, #0xff
         .db     #0
-        
+
         .dw     #(0x9000 + (0x20 << 4))
         .db     #-8, #0xff
         .db     #0
-        
+
         .dw     #(0x9000 + (0x2D << 4))
         .db     #8
         .db     #0xFF, #0xFF, #0xFF, #0xFF, #0xC3, #0xFF, #0xFF, #0xFF
@@ -470,9 +470,9 @@ loadfont:
         .ascii  " IE:"
         .ascii  "  BANK:"
         .ascii  "R"
-        .dw     __current_bank 
-        .ascii  "V" 
-        .dw     vCrashVBK 
+        .dw     __current_bank
+        .ascii  "V"
+        .dw     vCrashVBK
         .ascii  "W"
         .db     .SVBK, 0xff
         .ascii  " "
@@ -480,11 +480,11 @@ loadfont:
 
         .area   _DATA
 
-wCrashA: 
+wCrashA:
         .ds     1               ; We need at least one working register, and A allows accessing memory
-wCrashIE: 
+wCrashIE:
         .ds     1
-wCrashLCDC: 
+wCrashLCDC:
         .ds     1
 
 
@@ -500,29 +500,29 @@ wCrashLCDC:
         ; These are the initial values of the registers
         ; They are popped off the stack when printed, freeing up stack space
 
-vCrashAF: 
+vCrashAF:
         .ds     2
-vCrashBC: 
+vCrashBC:
         .ds     2
-vCrashDE: 
+vCrashDE:
         .ds     2
-vCrashHL: 
+vCrashHL:
         .ds     2
-vCrashSP: 
+vCrashSP:
         .ds     2
 
         .ds     SCRN_X_B
-vHeldKeys: 
+vHeldKeys:
         .ds     1               ; Keys held on previous frame
-vUnlockCounter: 
+vUnlockCounter:
         .ds     1               ; How many frames until dumps are "unlocked"
-vWhichDump: 
+vWhichDump:
         .ds     1
-vDumpHL: 
+vDumpHL:
         .ds     2
-vDumpSP: 
+vDumpSP:
         .ds     2
-vCrashVBK: 
+vCrashVBK:
         .ds     1
         .ds     4               ; Unused
 

--- a/src/core/events.c
+++ b/src/core/events.c
@@ -13,7 +13,7 @@ timer_time_t timer_values[MAX_CONCURRENT_TIMERS];
 
 void events_init(UBYTE preserve) BANKED {
     if (preserve) {
-        for (UBYTE i = 0; i < 8; i++) 
+        for (UBYTE i = 0; i < 8; i++)
             input_events[i].handle = 0;
     } else {
         memset(input_slots, 0, sizeof(input_slots));
@@ -39,7 +39,7 @@ void events_update(void) NONBANKED {
 
 void timers_init(UBYTE preserve) BANKED {
     if (preserve) {
-        for (UBYTE i = 0; i != MAX_CONCURRENT_TIMERS; i++) 
+        for (UBYTE i = 0; i != MAX_CONCURRENT_TIMERS; i++)
             timer_events[i].handle = 0;
     } else {
         memset(timer_values, 0, sizeof(timer_values));
@@ -59,8 +59,8 @@ void timers_update(void) NONBANKED {
                     script_execute(event->script_bank, event->script_addr, &event->handle, 0, 0);
                 }
             }
-        
+
         }
         ctimer++;
-    } 
+    }
 }

--- a/src/core/interrupt_sio.s
+++ b/src/core/interrupt_sio.s
@@ -24,7 +24,7 @@ _link_next_mode::
 .end_sio_globals:
 
         .area   _GSINIT
-        
+
         xor a
         ld  hl,#.start_sio_globals
         ld  c,#(.end_sio_globals - .start_sio_globals)
@@ -32,7 +32,7 @@ _link_next_mode::
 
         ld  a, #.IO_IDLE
         ld  (_SIO_status), a
-        
+
         ldh (.SC), a            ; use external clock
         ld  a, #.DT_IDLE
         ldh (.SB), a            ; send idle byte
@@ -110,19 +110,19 @@ _link_next_mode::
         ld  (_link_next_mode), a
 
         ld  a, #1
-        ld  (_link_byte_sent), a; link_byte_sent = TRUE 
+        ld  (_link_byte_sent), a; link_byte_sent = TRUE
 5$:
         pop de
         pop bc
         pop hl
 
         WAIT_STAT
-        
+
         pop af
         reti
 
         .area _CODE
-        
+
         ;; Send byte in __io_out to the serial port
 _SIO_send_byte::
         ld  a, #.IO_SENDING

--- a/src/core/interrupt_timer.s
+++ b/src/core/interrupt_timer.s
@@ -25,6 +25,6 @@
         pop hl
 
         WAIT_STAT
-        
+
         pop af
         reti

--- a/src/core/math.c
+++ b/src/core/math.c
@@ -6,50 +6,50 @@
 UBYTE isqrt(uint16_t x) NAKED BANKED {
        x;
 __asm
-	ldhl sp, #7
-	ld a, (hl-)
-	ld e, (hl)
-	
-	ld bc, #0xFFE0
-	ld h, b
-	ld l, b
-	ld d, b
-	
-	cp #0x40
-	jr c, 1$
-	sub #0x40
-	dec h
-	ld d, #0xEF
-	jr 1$
-0$:
-	add hl, bc
-	dec d
-	dec d
-1$:
-	add d
-	jr c, 0$
+    ldhl sp, #7
+    ld a, (hl-)
+    ld e, (hl)
 
-	sub d
-	ld d, h
-	ld h, a
-	
-	ld a, e
-	ld e, l
-	ld l, a
+    ld bc, #0xFFE0
+    ld h, b
+    ld l, b
+    ld d, b
+
+    cp #0x40
+    jr c, 1$
+    sub #0x40
+    dec h
+    ld d, #0xEF
+    jr 1$
+0$:
+    add hl, bc
+    dec d
+    dec d
+1$:
+    add d
+    jr c, 0$
+
+    sub d
+    ld d, h
+    ld h, a
+
+    ld a, e
+    ld e, l
+    ld l, a
 
 
 2$:
-	add hl, de
-	dec e
-	dec e
-	jr c, 2$
-	
+    add hl, de
+    dec e
+    dec e
+    jr c, 2$
+
     inc e
-	rr d
-	ld a, e
-	rra
-	cpl
-	ret
+    rr d
+    ld a, e
+    rra
+    cpl
+    ret
 __endasm;
 }
 #else

--- a/src/core/palette.c
+++ b/src/core/palette.c
@@ -47,7 +47,7 @@ __asm
         dec b
         jr nz, 1$
 
-        ret   
+        ret
 __endasm;
 }
 #endif

--- a/src/core/parallax.c
+++ b/src/core/parallax.c
@@ -9,10 +9,10 @@
 parallax_row_t parallax_rows[3];
 parallax_row_t * parallax_row;
 
-static const parallax_row_t parallax_rows_defaults[3] = { PARALLAX_STEP(0, 2, 2), PARALLAX_STEP(2, 4, 1), PARALLAX_STEP(4, 0, 0)}; 
+static const parallax_row_t parallax_rows_defaults[3] = { PARALLAX_STEP(0, 2, 2), PARALLAX_STEP(2, 4, 1), PARALLAX_STEP(4, 0, 0)};
 
 void parallax_init(void) BANKED {
-    memcpy(parallax_rows, parallax_rows_defaults, sizeof(parallax_rows)); 
+    memcpy(parallax_rows, parallax_rows_defaults, sizeof(parallax_rows));
 }
 
 void parallax_LCD_isr(void) NONBANKED NAKED {
@@ -48,16 +48,16 @@ __asm
         jr z, 3$
 
         ld  de, #4
-        add  hl, de             ; skip shift, tile_start, tile_height, shadow_scx 
+        add  hl, de             ; skip shift, tile_start, tile_height, shadow_scx
 
         ld d, h
-        ld a, l   
-        ld hl,#_parallax_row 
+        ld a, l
+        ld hl,#_parallax_row
         ld (hl+), a
         ld (hl), d
         ret
 3$:
-        ld hl,#_parallax_row 
+        ld hl,#_parallax_row
         ld a, #<_parallax_rows
         ld (hl+), a
         ld (hl), #>_parallax_rows

--- a/src/core/projectiles.c
+++ b/src/core/projectiles.c
@@ -136,7 +136,7 @@ void projectiles_update(void) NONBANKED {
             }
 #if PROJECTILES_COLLISION_SPREAD != EVERY_FRAME
         }
-#endif        
+#endif
 
         prev_projectile = projectile;
         projectile = projectile->next;
@@ -212,7 +212,7 @@ void projectile_launch(UBYTE index, upoint16_t *pos, UBYTE angle) BANKED {
         } else if (angle == ANGLE_DOWN) {
             projectile->pos.y += initial_offset;
             projectile->delta_pos.x = 0;
-            projectile->delta_pos.y = move_speed;            
+            projectile->delta_pos.y = move_speed;
         } else {
             INT8 sinv = SIN(angle), cosv = COS(angle);
 

--- a/src/core/scroll.c
+++ b/src/core/scroll.c
@@ -63,7 +63,7 @@ void scroll_reset(void) BANKED {
     scroll_x        = 0x7FFF;
     scroll_y        = 0x7FFF;
 
-    game_time       = 0; // was in scroll_render_rows() - that is insane, here is not the best place either 
+    game_time       = 0; // was in scroll_render_rows() - that is insane, here is not the best place either
 }
 
 void scroll_update(void) BANKED {
@@ -111,7 +111,7 @@ UBYTE scroll_viewport(parallax_row_t * port) {
             shift_scroll_x = draw_scroll_x >> port->shift;
         }
 
-        port->shadow_scx = shift_scroll_x;        
+        port->shadow_scx = shift_scroll_x;
         UBYTE shift_col = PX_TO_TILE(shift_scroll_x);
 
         // If column is +/- 1 just render next column
@@ -126,8 +126,8 @@ UBYTE scroll_viewport(parallax_row_t * port) {
         } else if (current_col != new_col) {
             // If column differs by more than 1 render entire viewport
             scroll_render_rows(shift_scroll_x, 0, port->start_tile, port->tile_height);
-        }  
-        return FALSE;   
+        }
+        return FALSE;
     } else {
         // last parallax slice OR no parallax
         port->shadow_scx = draw_scroll_x;
@@ -202,7 +202,7 @@ void scroll_render_rows(INT16 scroll_x, INT16 scroll_y, BYTE row_offset, BYTE n_
 void scroll_queue_row(UBYTE x, UBYTE y) {
     while (pending_w_i) {
         // If previous row wasn't fully rendered
-        // render it now before starting next row        
+        // render it now before starting next row
         scroll_load_pending_row();
     }
 
@@ -272,7 +272,7 @@ void scroll_load_row(UBYTE x, UBYTE y) NONBANKED {
 
 void scroll_load_col(UBYTE x, UBYTE y, UBYTE height) NONBANKED {
     _save_bank = CURRENT_BANK;
- 
+
 #ifdef CGB
     if (_is_CGB) {  // Color Column Load
         SWITCH_ROM(image_attr_bank);

--- a/src/core/scroll_a.s
+++ b/src/core/scroll_a.s
@@ -21,7 +21,7 @@ _GetBkgAddr::
 
 .area _CODE_255
 
-; void scroll_rect(UBYTE * base_addr, UBYTE w, UBYTE h, UBYTE fill) BANKED; 
+; void scroll_rect(UBYTE * base_addr, UBYTE w, UBYTE h, UBYTE fill) BANKED;
 .globl b_scroll_rect
 b_scroll_rect = 255
 

--- a/src/core/set_tile_submap.s
+++ b/src/core/set_tile_submap.s
@@ -71,7 +71,7 @@ _set_xy_win_submap::
         ldh     a, (__current_bank)
         push    af
         ld      a, (hl+)
-        ldh	(__current_bank),a
+        ldh    (__current_bank),a
         ld      (#rROMB0), a
 
         ld      a, (hl+)
@@ -96,7 +96,7 @@ _set_xy_win_submap::
         call    .set_xy_win_submap
 
         pop     af
-        ldh	(__current_bank),a
+        ldh    (__current_bank),a
         ld      (#rROMB0), a
         ret
 

--- a/src/core/sgb_border.c
+++ b/src/core/sgb_border.c
@@ -13,7 +13,7 @@
 #define SGB_SCR_FREEZE 1
 #define SGB_SCR_UNFREEZE 0
 
-#define SGB_TRANSFER(A,B) map_buf[0]=(A),map_buf[1]=(B),sgb_transfer(map_buf) 
+#define SGB_TRANSFER(A,B) map_buf[0]=(A),map_buf[1]=(B),sgb_transfer(map_buf)
 
 void set_sgb_border(unsigned char * tiledata, size_t tiledata_size, UBYTE tiledata_bank,
                     unsigned char * tilemap,  size_t tilemap_size,  UBYTE tilemap_bank,
@@ -21,7 +21,7 @@ void set_sgb_border(unsigned char * tiledata, size_t tiledata_size, UBYTE tileda
     unsigned char map_buf[20];
     memset(map_buf, 0, sizeof(map_buf));
 
-    SGB_TRANSFER((SGB_MASK_EN << 3) | 1, SGB_SCR_FREEZE); 
+    SGB_TRANSFER((SGB_MASK_EN << 3) | 1, SGB_SCR_FREEZE);
 
     BGP_REG = OBP0_REG = OBP1_REG = 0xE4U;
     SCX_REG = SCY_REG = 0U;
@@ -43,15 +43,15 @@ void set_sgb_border(unsigned char * tiledata, size_t tiledata_size, UBYTE tileda
 
     // transfer tile data
     UBYTE ntiles = (tiledata_size > 256 * 32) ? 0 : tiledata_size >> 5;
-    if ((!ntiles) || (ntiles > 128U)) { 
-        SetBankedBkgData(0, 0, tiledata, tiledata_bank); 
+    if ((!ntiles) || (ntiles > 128U)) {
+        SetBankedBkgData(0, 0, tiledata, tiledata_bank);
         SGB_TRANSFER((SGB_CHR_TRN << 3) | 1, SGB_CHR_BLOCK0);
-        if (ntiles) ntiles -= 128U; 
+        if (ntiles) ntiles -= 128U;
         tiledata += (128 * 32);
-        SetBankedBkgData(0, ntiles << 1, tiledata, tiledata_bank); 
+        SetBankedBkgData(0, ntiles << 1, tiledata, tiledata_bank);
         SGB_TRANSFER((SGB_CHR_TRN << 3) | 1, SGB_CHR_BLOCK1);
-    } else { 
-        SetBankedBkgData(0, ntiles << 1, tiledata, tiledata_bank); 
+    } else {
+        SetBankedBkgData(0, ntiles << 1, tiledata, tiledata_bank);
         SGB_TRANSFER((SGB_CHR_TRN << 3) | 1, SGB_CHR_BLOCK0);
     }
 
@@ -66,6 +66,6 @@ void set_sgb_border(unsigned char * tiledata, size_t tiledata_size, UBYTE tileda
     memset(map_buf, 0, 16);
     set_bkg_data(0, 1, map_buf);
     fill_bkg_rect(0, 0, 20, 18, 0);
-    
-    SGB_TRANSFER((SGB_MASK_EN << 3) | 1, SGB_SCR_UNFREEZE); 
+
+    SGB_TRANSFER((SGB_MASK_EN << 3) | 1, SGB_SCR_UNFREEZE);
 }

--- a/src/core/states_caller.s
+++ b/src/core/states_caller.s
@@ -21,21 +21,20 @@ state_call:
         add e                   ; a *= sizeof(far_ptr)
 
         ADD_A_REG16 h, l        ; hl = far_ptr_array[a]
-        
+
         ldh a, (#__current_bank)
         push af                 ; save current bank
-        
+
         ld a, (hl+)             ; load bank
         ldh (#__current_bank), a
         ld (#rROMB0), a         ; switch to routine bank
-        
+
         ld a, (hl+)
         ld h, (hl)
         ld l, a                 ; load offset
         rst 0x20                ; call hl
 
-        pop af       
+        pop af
         ldh (#__current_bank), a
         ld (#rROMB0), a         ; restore bank
         ret
-        

--- a/src/core/trigger.c
+++ b/src/core/trigger.c
@@ -49,10 +49,10 @@ UBYTE trigger_activate_at_intersection(rect16_t *bb, upoint16_t *offset, UBYTE f
         return FALSE;
     }
 
-    if (last_trigger != NO_TRIGGER_COLLISON && 
+    if (last_trigger != NO_TRIGGER_COLLISON &&
         (hit_trigger == NO_TRIGGER_COLLISON || hit_trigger != last_trigger)) {
         UBYTE trigger_script_called = FALSE;
-        
+
         if (hit_trigger != NO_TRIGGER_COLLISON && triggers[hit_trigger].script_flags & TRIGGER_HAS_ENTER_SCRIPT) {
             script_execute(triggers[hit_trigger].script.bank, triggers[hit_trigger].script.ptr, 0, 1, 1);
             trigger_script_called = TRUE;
@@ -60,7 +60,7 @@ UBYTE trigger_activate_at_intersection(rect16_t *bb, upoint16_t *offset, UBYTE f
 
         if (triggers[last_trigger].script_flags & TRIGGER_HAS_LEAVE_SCRIPT) {
             script_execute(
-                triggers[last_trigger].script.bank, 
+                triggers[last_trigger].script.bank,
                 triggers[last_trigger].script.ptr, 0, 1, 2);
             trigger_script_called = TRUE;
         }
@@ -69,7 +69,7 @@ UBYTE trigger_activate_at_intersection(rect16_t *bb, upoint16_t *offset, UBYTE f
 
         return trigger_script_called;
     }
-    
+
     last_trigger = hit_trigger;
 
     if (hit_trigger != NO_TRIGGER_COLLISON && triggers[hit_trigger].script_flags & TRIGGER_HAS_ENTER_SCRIPT) {

--- a/src/core/vm_actor.c
+++ b/src/core/vm_actor.c
@@ -76,14 +76,14 @@ static UWORD check_collision_horizontal(UWORD start_x, UWORD start_y, rect16_t *
         tx2 = SUBPX_TO_TILE(end_pos + bounds->right);
         if (tx2 < tx1) {
             tx2 = image_tile_width;
-        }            
+        }
     }
     while (ty1 != ty2) {
         if (tile_col_test_range_x(tile_mask, ty1, tx1, tx2)) {
             return (start_x > end_pos) ?
-                   TILE_TO_SUBPX(tile_hit_x) - bounds->left + TILE_TO_SUBPX(1) : 
+                   TILE_TO_SUBPX(tile_hit_x) - bounds->left + TILE_TO_SUBPX(1) :
                    TILE_TO_SUBPX(tile_hit_x) - EXCLUSIVE_OFFSET(bounds->right);
-        }                
+        }
         ty1++;
     }
     return end_pos;
@@ -113,8 +113,8 @@ static UWORD check_collision_vertical(UWORD start_x, UWORD start_y, rect16_t *bo
     }
     while (tx1 != tx2) {
         if (tile_col_test_range_y(tile_mask, tx1, ty1, ty2)) {
-            return (start_y > end_pos) ? 
-                   TILE_TO_SUBPX(tile_hit_y) - bounds->top + TILE_TO_SUBPX(1) : 
+            return (start_y > end_pos) ?
+                   TILE_TO_SUBPX(tile_hit_y) - bounds->top + TILE_TO_SUBPX(1) :
                    TILE_TO_SUBPX(tile_hit_y) - EXCLUSIVE_OFFSET(bounds->bottom);
         }
         tx1++;
@@ -211,7 +211,7 @@ void vm_actor_move_to(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
         }
 
         THIS->PC -= (INSTRUCTION_SIZE + sizeof(idx));
-        return;        
+        return;
     }
 
     // Interrupt actor movement
@@ -270,7 +270,7 @@ void vm_actor_move_to(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
 
         // Check for actor collision
         actor_t *hit_actor;
-        if (test_actors && (hit_actor = actor_overlapping_bb(&actor->bounds, &actor->pos, actor))) { 
+        if (test_actors && (hit_actor = actor_overlapping_bb(&actor->bounds, &actor->pos, actor))) {
             actor->pos.y = hit_actor->pos.y +
                 (new_dir == DIR_UP
                     ? hit_actor->bounds.bottom - actor->bounds.top + 1
@@ -646,7 +646,7 @@ void vm_actor_move_to_x(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKED
 
     if (params->X == actor->pos.x) {
         // Already at destination
-        actor_set_anim_idle(actor);        
+        actor_set_anim_idle(actor);
         return;
     } else if (params->X < actor->pos.x) {
         // Moving left
@@ -702,7 +702,7 @@ void vm_actor_move_to_y(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKED
 
     act_move_to_t * params = VM_REF_TO_PTR(idx);
     actor = actors + (UBYTE)(params->ID);
-    
+
 
     // Interrupt actor movement
     if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
@@ -713,15 +713,15 @@ void vm_actor_move_to_y(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKED
 
     if (params->Y == actor->pos.y) {
         // Already at destination
-        actor_set_anim_idle(actor);        
+        actor_set_anim_idle(actor);
         return;
     } else if (params->Y < actor->pos.y) {
-        // Moving upwards 
+        // Moving upwards
         actor->pos.y -= actor->move_speed;
 
         // Check for actor collision
         actor_t *hit_actor;
-        if (test_actors && (hit_actor = actor_overlapping_bb(&actor->bounds, &actor->pos, actor))) { 
+        if (test_actors && (hit_actor = actor_overlapping_bb(&actor->bounds, &actor->pos, actor))) {
             actor->pos.y += actor->move_speed;
             params->X = actor->pos.x;
             actor_set_anim_idle(actor);
@@ -740,7 +740,7 @@ void vm_actor_move_to_y(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKED
 
         // Check for actor collision
         actor_t *hit_actor;
-        if (test_actors && (hit_actor = actor_overlapping_bb(&actor->bounds, &actor->pos, actor))) { 
+        if (test_actors && (hit_actor = actor_overlapping_bb(&actor->bounds, &actor->pos, actor))) {
             actor->pos.y -= actor->move_speed;
             params->X = actor->pos.x;
             actor_set_anim_idle(actor);
@@ -820,12 +820,12 @@ void vm_actor_move_to_xy(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKE
 
     if (!reached_y) {
         if (params->Y < actor->pos.y) {
-            // Moving upwards 
+            // Moving upwards
             actor->pos.y -= actor->move_speed;
 
             // Check for actor collision
             actor_t *hit_actor;
-            if (test_actors && (hit_actor = actor_overlapping_bb(&actor->bounds, &actor->pos, actor))) { 
+            if (test_actors && (hit_actor = actor_overlapping_bb(&actor->bounds, &actor->pos, actor))) {
                 actor->pos.y += actor->move_speed;
                 params->X = actor->pos.x;
                 reached_y = TRUE;
@@ -842,7 +842,7 @@ void vm_actor_move_to_xy(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKE
 
             // Check for actor collision
             actor_t *hit_actor;
-            if (test_actors && (hit_actor = actor_overlapping_bb(&actor->bounds, &actor->pos, actor))) { 
+            if (test_actors && (hit_actor = actor_overlapping_bb(&actor->bounds, &actor->pos, actor))) {
                 actor->pos.y -= actor->move_speed;
                 params->X = actor->pos.x;
                 reached_y = TRUE;
@@ -871,7 +871,7 @@ void vm_actor_move_to_set_dir_x(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
 
     act_move_to_t * params = VM_REF_TO_PTR(idx);
     actor = actors + (UBYTE)(params->ID);
-    
+
     // Interrupt actor movement
     if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
         return;
@@ -887,7 +887,7 @@ void vm_actor_move_to_set_dir_y(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
 
     act_move_to_t * params = VM_REF_TO_PTR(idx);
     actor = actors + (UBYTE)(params->ID);
-    
+
     // Interrupt actor movement
     if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
         return;
@@ -903,6 +903,6 @@ void vm_actor_set_anim_moving(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
 
     act_move_to_t * params = VM_REF_TO_PTR(idx);
     actor = actors + (UBYTE)(params->ID);
-    
+
     actor_set_anim(actor, actor->dir + N_DIRECTIONS);
 }

--- a/src/core/vm_camera.c
+++ b/src/core/vm_camera.c
@@ -48,7 +48,7 @@ void vm_camera_move_to(SCRIPT_CTX * THIS, INT16 idx, UBYTE speed, UBYTE after_lo
         if (camera_x >= params->X) {
             camera_x = params->X;
             x_dest = TRUE;
-        }        
+        }
     }
 
     if (camera_y > params->Y) {
@@ -59,7 +59,7 @@ void vm_camera_move_to(SCRIPT_CTX * THIS, INT16 idx, UBYTE speed, UBYTE after_lo
             if (x_dest) {
                 return;
             }
-        }        
+        }
     } else if (camera_y < params->Y) {
         // Move down
         camera_y += speed;
@@ -68,7 +68,7 @@ void vm_camera_move_to(SCRIPT_CTX * THIS, INT16 idx, UBYTE speed, UBYTE after_lo
             if (x_dest) {
                 return;
             }
-        }      
+        }
     }
 
     THIS->PC -= (INSTRUCTION_SIZE + sizeof(idx) + sizeof(speed) + sizeof(after_lock_camera));

--- a/src/core/vm_ui_a.s
+++ b/src/core/vm_ui_a.s
@@ -37,7 +37,7 @@ _itoa_fmt::
     cpl
     ld      E, A
     inc     DE
-    
+
     ld      HL, #__itoa_fmt_len
     ld      A, (HL)
     or      A
@@ -72,7 +72,7 @@ _itoa_fmt::
     push    BC
 
     ld      HL, #(.itoa_fmt_buf + 2)
-    
+
     xor     A           ; clear value
     ld      (HL-), A
     ld      (HL-), A
@@ -82,7 +82,7 @@ _itoa_fmt::
 1$:
     sla     E
     rl      D
-    
+
     ld      A, (HL)
     adc     A
     daa
@@ -108,24 +108,24 @@ _itoa_fmt::
     jr      Z, 8$
     ld      D, A
     ld      A, #'0'
-9$: 
+9$:
     ld      (BC), A
     inc     BC
     dec     D
     jr      NZ, 9$
     ld      A, #5
     ld      (__itoa_fmt_len), A
-8$: 
+8$:
 
     ld      A, (__itoa_fmt_len)
     or      A
     jr      Z, 7$
     ld      A, #1
-7$: 
+7$:
     ld      D, A
     ld      E, #'0'
     ld      HL, #(.itoa_fmt_buf + 2)
-    
+
     ld      A, (HL-)
     and     #0x0f
     add     D
@@ -141,7 +141,7 @@ _itoa_fmt::
     jr      Z, 3$
     cp      #5
     jr      NC, 3$
-    dec     BC  
+    dec     BC
 3$:
     ld      A, (HL)
     swap    A
@@ -159,7 +159,7 @@ _itoa_fmt::
     jr      Z, 4$
     cp      #4
     jr      NC, 4$
-    dec     BC  
+    dec     BC
 4$:
     ld      A, (HL-)
     and     #0x0f
@@ -169,14 +169,14 @@ _itoa_fmt::
     add     A, E
     ld      D, #1       ; make D nonzero
     ld      (BC), A
-    inc     BC  
+    inc     BC
 
     ld      A, (__itoa_fmt_len)
     or      A
     jr      Z, 5$
     cp      #3
     jr      NC, 5$
-    dec     BC  
+    dec     BC
 5$:
     ld      A, (HL)
     swap    A
@@ -193,16 +193,15 @@ _itoa_fmt::
     jr      Z, 6$
     cp      #2
     jr      NC, 6$
-    dec     BC  
+    dec     BC
 6$:
     ld      A, (HL)
     and     #0x0f
     add     A, E
     ld      (BC), A
     inc     BC
-    
+
     xor     A
     ld      (BC), A     ; write trailing #0
 
     ret
-    

--- a/src/states/adventure.c
+++ b/src/states/adventure.c
@@ -235,8 +235,8 @@ inline void adv_restore_default_anim_state(void)
 {
     if (adv_anim_dirty) {
         load_animations(PLAYER.sprite.ptr, PLAYER.sprite.bank, 0, PLAYER.animations);
-        actor_reset_anim(&PLAYER);  
-        adv_anim_dirty = FALSE;             
+        actor_reset_anim(&PLAYER);
+        adv_anim_dirty = FALSE;
     }
 }
 
@@ -350,7 +350,7 @@ void adventure_update(void) BANKED {
                 state_exit_run();
                 break;
             }
-#endif              
+#endif
 #ifdef FEAT_ADVENTURE_DASH
             case DASH_STATE: {
                 state_exit_dash();
@@ -391,7 +391,7 @@ void adventure_update(void) BANKED {
                 state_enter_run();
                 break;
             }
-#endif            
+#endif
 #ifdef FEAT_ADVENTURE_DASH
             case DASH_STATE: {
                 state_enter_dash();
@@ -416,7 +416,7 @@ void adventure_update(void) BANKED {
                 break;
             }
 #endif
-        }  
+        }
     }
 
 
@@ -473,7 +473,7 @@ void adventure_update(void) BANKED {
         } else if (camera_deadzone_x < adv_camera_deadzone_x) {
             camera_deadzone_x++;
         }
-        
+
         if (camera_deadzone_y > adv_camera_deadzone_y) {
             camera_deadzone_y--;
         } else if (camera_deadzone_y < adv_camera_deadzone_y) {
@@ -495,7 +495,7 @@ static void handle_dir_input(void) {
     const WORD base_acc = (adv_state == RUN_STATE) ? adv_run_acc : adv_walk_acc;
 #else
     const WORD max_vel = adv_walk_vel;
-    const WORD base_acc = adv_walk_acc;    
+    const WORD base_acc = adv_walk_acc;
 #endif
 
 #if INPUT_ADVENTURE_MOVE_TYPE == MOVE_TYPE_8_WAY
@@ -513,8 +513,8 @@ static void handle_dir_input(void) {
 
     if (target_x && target_y) {
         // Approximate diagonal movement normalization
-        target_x = (target_x >> 1) + (target_x >> 2);  
-        target_y = (target_y >> 1) + (target_y >> 2);  
+        target_x = (target_x >> 1) + (target_x >> 2);
+        target_y = (target_y >> 1) + (target_y >> 2);
     }
 #if INPUT_ADVENTURE_DIRECTION_TYPE == DIRECTION_TYPE_4_WAY
     // Update facing priority axis
@@ -534,17 +534,17 @@ static void handle_dir_input(void) {
             facing_dir = left ? DIR_LEFT : DIR_RIGHT;
         } else {
             facing_dir = up ? DIR_UP : DIR_DOWN;
-        }	
+        }
 #else
-	    facing_dir = left ? DIR_LEFT : DIR_RIGHT;
+        facing_dir = left ? DIR_LEFT : DIR_RIGHT;
 #endif
     } else if (left) {
         facing_dir = DIR_LEFT;
     } else if (right) {
         facing_dir = DIR_RIGHT;
-    } 
+    }
 #if INPUT_ADVENTURE_DIRECTION_TYPE != DIRECTION_TYPE_HORIZONTAL
-	else if (up) {
+    else if (up) {
         facing_dir = DIR_UP;
     } else if (down) {
         facing_dir = DIR_DOWN;
@@ -567,7 +567,7 @@ static void handle_dir_input(void) {
         facing_dir = DIR_DOWN;
     }
 #else
-	if (INPUT_RECENT_LEFT) {
+    if (INPUT_RECENT_LEFT) {
         target_x = -max_vel;
         facing_dir = DIR_LEFT;
     } else if (INPUT_RECENT_RIGHT) {
@@ -656,7 +656,7 @@ static void move_and_collide(UBYTE mask)
                             }
                         }
                     }
-                } 
+                }
             }
             new_x = MIN(image_width_subpx - EXCLUSIVE_OFFSET(PLAYER.bounds.right), new_x);
         } else if (delta.x < 0) {
@@ -719,25 +719,25 @@ static void move_and_collide(UBYTE mask)
                             adv_attached_actor = NULL;
                             PLAYER.pos.x -= VEL_TO_SUBPX(adv_walk_vel);
                             if (PLAYER.pos.x < target_x) {
-                                PLAYER.pos.x = target_x;   
+                                PLAYER.pos.x = target_x;
                             }
-                        }                            
+                        }
                     } else if (tile & COLLISION_RIGHT) {
                         UWORD target_x = TILE_TO_SUBPX(tile_hit_x + 1) + 1 - EXCLUSIVE_OFFSET(PLAYER.bounds.left);
                         if (PLAYER.pos.x > target_x - MAX_CORNER_PUSH_DISTANCE) {
                             adv_attached_actor = NULL;
                             PLAYER.pos.x += VEL_TO_SUBPX(adv_walk_vel);
                             if (PLAYER.pos.x > target_x) {
-                                PLAYER.pos.x = target_x;   
+                                PLAYER.pos.x = target_x;
                             }
                         }
-                    }                        
+                    }
                 }
             }
         } else if (delta.y < 0) {
             UBYTE tile_y = SUBPX_TO_TILE(new_y + PLAYER.bounds.top);
             UBYTE tile = tile_col_test_range_x(COLLISION_BOTTOM, tile_y, tile_start, tile_end);
-            if (tile) {            
+            if (tile) {
                 new_y = TILE_TO_SUBPX(tile_y + 1) - PLAYER.bounds.top;
                 adv_vel_y = 0;
                 if (tile & COLLISION_SLOPE && delta.x == 0) {
@@ -747,16 +747,16 @@ static void move_and_collide(UBYTE mask)
                             adv_attached_actor = NULL;
                             PLAYER.pos.x -= VEL_TO_SUBPX(adv_walk_vel);
                             if (PLAYER.pos.x < target_x) {
-                                PLAYER.pos.x = target_x;   
-                            }  
-                        }                          
+                                PLAYER.pos.x = target_x;
+                            }
+                        }
                     } else if (tile & COLLISION_RIGHT) {
                         UWORD target_x = TILE_TO_SUBPX(tile_hit_x + 1) + 1 - EXCLUSIVE_OFFSET(PLAYER.bounds.left);
                         if (PLAYER.pos.x > target_x - MAX_CORNER_PUSH_DISTANCE) {
                             adv_attached_actor = NULL;
                             PLAYER.pos.x += VEL_TO_SUBPX(adv_walk_vel);
                             if (PLAYER.pos.x > target_x) {
-                                PLAYER.pos.x = target_x;   
+                                PLAYER.pos.x = target_x;
                             }
                         }
                     }
@@ -805,7 +805,7 @@ static void move_and_collide(UBYTE mask)
         if (adv_attached_actor != NULL) {
             hit_actor = adv_attached_actor;
             adv_attached_prev_x = hit_actor->pos.x;
-            adv_attached_prev_y = hit_actor->pos.y; 
+            adv_attached_prev_y = hit_actor->pos.y;
         } else {
             hit_actor = initial_hit_actor;
             adv_attached_actor = NULL;
@@ -825,13 +825,13 @@ static void move_and_collide(UBYTE mask)
                 actor_set_dir(hit_actor, FLIPPED_DIR(PLAYER.dir), FALSE);
                 script_execute(hit_actor->script.bank, hit_actor->script.ptr, 0, 1, 0);
             }
-        }        
+        }
     }
 
     if (mask & COL_CHECK_TRIGGERS)
     {
         trigger_activate_at_intersection(&PLAYER.bounds, &PLAYER.pos, FALSE);
-    }    
+    }
 }
 
 
@@ -1011,7 +1011,7 @@ static void state_update_ground(void)
         WORD delta_mp_y = adv_attached_actor->pos.y - adv_attached_prev_y;
         adv_attached_prev_x = adv_attached_actor->pos.x;
         adv_attached_prev_y = adv_attached_actor->pos.y;
-        
+
         if (collision_dir == DIR_DOWN && delta_mp_y > adv_vel_y) {
             adv_vel_y = MAX(0, DELTA_TO_VEL(delta_mp_y));
         } else if (collision_dir == DIR_UP && delta_mp_y < adv_vel_y) {
@@ -1039,7 +1039,7 @@ static void state_update_ground(void)
         if (adv_push_timer == adv_push_delay_frames) {
             adv_next_state = PUSH_STATE;
             return;
-        }                
+        }
         adv_push_timer++;
     } else {
         adv_push_timer = 0;
@@ -1070,7 +1070,7 @@ static void state_update_ground(void)
     } else {
         actor_set_anim_idle(&PLAYER);
     }
-    
+
 }
 
 // DASH_STATE
@@ -1085,7 +1085,7 @@ static void state_enter_dash(void)
     }
 #ifdef ADVENTURE_DASH_ANIM
     adv_set_player_anim_state(ADVENTURE_DASH_ANIM);
-#elif ADVENTURE_ANIM_OVERRIDES_SET  
+#elif ADVENTURE_ANIM_OVERRIDES_SET
     adv_restore_default_anim_state();
 #endif
     adv_callback_execute(DASH_INIT);
@@ -1241,7 +1241,7 @@ static void state_exit_push(void)
 static void state_update_push(void)
 {
     handle_dir_input();
-  
+
     delta.x = VEL_TO_SUBPX(adv_vel_x);
     delta.y = VEL_TO_SUBPX(adv_vel_y);
 

--- a/src/states/platform.c
+++ b/src/states/platform.c
@@ -120,7 +120,7 @@
 #define COLLISION_SLOPE_225_RIGHT_BOT COLLISION_SLOPE_225_BOT
 #define COLLISION_SLOPE_225_RIGHT_TOP COLLISION_SLOPE_225_TOP
 #define COLLISION_SLOPE_45_LEFT       (COLLISION_SLOPE_LEFT | COLLISION_SLOPE_45)
-#define COLLISION_SLOPE_225_LEFT_BOT  (COLLISION_SLOPE_LEFT | COLLISION_SLOPE_225_BOT) 
+#define COLLISION_SLOPE_225_LEFT_BOT  (COLLISION_SLOPE_LEFT | COLLISION_SLOPE_225_BOT)
 #define COLLISION_SLOPE_225_LEFT_TOP  (COLLISION_SLOPE_LEFT | COLLISION_SLOPE_225_TOP)
 #define COLLISION_SLOPE_ANY           (COLLISION_SLOPE_45 | COLLISION_SLOPE_225_BOT | COLLISION_SLOPE_225_TOP)
 #define COLLISION_SLOPE               0x70u
@@ -396,7 +396,7 @@ inline UBYTE dash_input_pressed(void)
 #elif INPUT_PLATFORM_DASH == DASH_INPUT_A
     return INPUT_PRESSED(INPUT_A);
 #elif INPUT_PLATFORM_DASH == DASH_INPUT_B
-    return INPUT_PRESSED(INPUT_B);    
+    return INPUT_PRESSED(INPUT_B);
 #elif INPUT_PLATFORM_DASH == DASH_INPUT_DOUBLE_TAP
     // Double-Tap Dash
     if (INPUT_PRESSED(INPUT_LEFT))
@@ -421,7 +421,7 @@ inline UBYTE dash_input_pressed(void)
             plat_tap_timer = DOUBLE_TAP_WINDOW;
         }
     }
-    return FALSE;    
+    return FALSE;
 #elif INPUT_PLATFORM_DASH == DASH_INPUT_DOWN_JUMP
     return (INPUT_PRESSED(INPUT_DOWN) && INPUT_PLATFORM_JUMP) || (INPUT_DOWN && INPUT_PRESSED(INPUT_PLATFORM_JUMP));
 #else
@@ -444,56 +444,56 @@ inline void plat_restore_default_anim_state(void)
 {
     if (plat_anim_dirty) {
         load_animations(PLAYER.sprite.ptr, PLAYER.sprite.bank, 0, PLAYER.animations);
-        actor_reset_anim(&PLAYER);  
-        plat_anim_dirty = FALSE;             
+        actor_reset_anim(&PLAYER);
+        plat_anim_dirty = FALSE;
     }
 }
 
 #endif
 
-static void state_enter_fall(void);      
-static void state_exit_fall(void);      
+static void state_enter_fall(void);
+static void state_exit_fall(void);
 static void state_update_fall(void);
-static void state_enter_ground(void);    
-static void state_exit_ground(void);    
+static void state_enter_ground(void);
+static void state_exit_ground(void);
 static void state_update_ground(void);
 #ifdef FEAT_PLATFORM_JUMP
-static void state_enter_jump(void);      
-static void state_exit_jump(void);      
+static void state_enter_jump(void);
+static void state_exit_jump(void);
 static void state_update_jump(void);
 #endif
 #ifdef FEAT_PLATFORM_DASH
-static void state_enter_dash(void);      
-static void state_exit_dash(void);      
+static void state_enter_dash(void);
+static void state_exit_dash(void);
 static void state_update_dash(void);
 #endif
 #ifdef FEAT_PLATFORM_LADDERS
-static void state_enter_ladder(void);    
-static void state_exit_ladder(void);    
+static void state_enter_ladder(void);
+static void state_exit_ladder(void);
 static void state_update_ladder(void);
 #endif
 #ifdef FEAT_PLATFORM_WALL_JUMP
-static void state_enter_wall(void);      
-static void state_exit_wall(void);      
+static void state_enter_wall(void);
+static void state_exit_wall(void);
 static void state_update_wall(void);
 #endif
 #ifdef FEAT_PLATFORM_KNOCKBACK
-static void state_enter_knockback(void); 
-static void state_exit_knockback(void); 
+static void state_enter_knockback(void);
+static void state_exit_knockback(void);
 static void state_update_knockback(void);
 #endif
 #ifdef FEAT_PLATFORM_BLANK
-static void state_enter_blank(void);     
-static void state_exit_blank(void);     
+static void state_enter_blank(void);
+static void state_exit_blank(void);
 static void state_update_blank(void);
 #endif
 #ifdef FEAT_PLATFORM_RUN
-static void state_enter_run(void);       
-static void state_exit_run(void);       
+static void state_enter_run(void);
+static void state_exit_run(void);
 #endif
 #ifdef FEAT_PLATFORM_FLOAT
-static void state_enter_float(void);     
-static void state_exit_float(void);     
+static void state_enter_float(void);
+static void state_exit_float(void);
 #endif
 
 // End of Function Definitions ------------------------------------------------
@@ -601,7 +601,7 @@ void platform_update(void) BANKED
             break;
         }
 #endif
-#ifdef FEAT_PLATFORM_JUMP        
+#ifdef FEAT_PLATFORM_JUMP
         case JUMP_STATE: {
             state_exit_jump();
             break;
@@ -615,8 +615,8 @@ void platform_update(void) BANKED
         case RUN_STATE: {
             state_exit_run();
             break;
-        }  
-#endif      
+        }
+#endif
 #ifdef FEAT_PLATFORM_LADDERS
         case LADDER_STATE: {
             state_exit_ladder();
@@ -667,7 +667,7 @@ void platform_update(void) BANKED
         }
 #endif
 
-#ifdef FEAT_PLATFORM_JUMP        
+#ifdef FEAT_PLATFORM_JUMP
         case JUMP_STATE: {
             state_enter_jump();
             break;
@@ -681,7 +681,7 @@ void platform_update(void) BANKED
         case RUN_STATE: {
             state_enter_run();
             break;
-        }  
+        }
 #endif
 #ifdef FEAT_PLATFORM_LADDERS
         case LADDER_STATE: {
@@ -935,8 +935,8 @@ static void dash_init(void)
         if (col) {
             plat_next_state = FALL_STATE;
             return;
-        }     
-#endif        
+        }
+#endif
     }
 
     plat_is_actor_attached = FALSE;
@@ -1142,7 +1142,7 @@ static void move_and_collide(UBYTE mask)
         }
 
         UBYTE tile_x = SUBPX_TO_TILE(new_x + bounds_edge);
-        
+
         UBYTE tile = tile_col_test_range_y(hit_flag, tile_x, tile_y_start, tile_y_end);
 
         if (tile)
@@ -1160,7 +1160,7 @@ static void move_and_collide(UBYTE mask)
                 (IS_SLOPE_LEFT(prev_on_slope) != moving_right)))
             {
                 goto finally_update_x;
-            }               
+            }
 #endif
             if (moving_right)
             {
@@ -1409,7 +1409,7 @@ finally_check_actor_col:
                     {
                         const UBYTE moving_right = PLAYER.pos.x < hit_actor->pos.x;
 
-                        plat_delta_x = (hit_actor->pos.x - PLAYER.pos.x) + 
+                        plat_delta_x = (hit_actor->pos.x - PLAYER.pos.x) +
                             (moving_right
                                 ? (hit_actor->bounds.left - EXCLUSIVE_OFFSET(PLAYER.bounds.right))
                                 : (EXCLUSIVE_OFFSET(hit_actor->bounds.right) - PLAYER.bounds.left));
@@ -1499,10 +1499,10 @@ static void state_enter_fall(void) {
     plat_is_actor_attached = FALSE;
 #ifdef PLATFORM_FALL_ANIM
     plat_set_player_anim_state(PLATFORM_FALL_ANIM);
-#elif PLATFORM_ANIM_OVERRIDES_SET  
+#elif PLATFORM_ANIM_OVERRIDES_SET
     plat_restore_default_anim_state();
 #endif
-    plat_callback_execute(FALL_INIT); 
+    plat_callback_execute(FALL_INIT);
 }
 
 static void state_exit_fall(void) {
@@ -1858,7 +1858,7 @@ static void state_enter_jump(void) {
     // Calculate jump boost value based on horizontal velocity
     if (plat_run_boost != 0) {
         UWORD abs_vel_x = MAX(plat_vel_x, -plat_vel_x);
-#ifdef FEAT_PLATFORM_RUN                
+#ifdef FEAT_PLATFORM_RUN
         UBYTE boost_ratio = abs_vel_x / (plat_run_vel >> 7);
 #else
         UBYTE boost_ratio = abs_vel_x / (plat_walk_vel >> 7);
@@ -1893,7 +1893,7 @@ static void state_update_jump(void) {
         plat_vel_y = MIN(reduced_vel_y, 0);
 #endif
 
-        // Handle jump velocity overflow 
+        // Handle jump velocity overflow
         if (plat_vel_y > 0) {
             plat_vel_y = WORD_MIN;
         }
@@ -2028,7 +2028,7 @@ static void state_enter_dash(void) {
     }
 #ifdef PLATFORM_DASH_ANIM
     plat_set_player_anim_state(PLATFORM_DASH_ANIM);
-#elif PLATFORM_ANIM_OVERRIDES_SET  
+#elif PLATFORM_ANIM_OVERRIDES_SET
     plat_restore_default_anim_state();
 #endif
     plat_callback_execute(DASH_INIT);
@@ -2312,7 +2312,7 @@ static void state_update_ladder(void) {
         actor_set_anim_idle(&PLAYER);
 #else
         actor_stop_anim(&PLAYER);
-#endif            
+#endif
     } else {
         actor_set_anim(&PLAYER, ANIM_CLIMB);
     }
@@ -2332,10 +2332,10 @@ static void state_enter_wall(void) {
     plat_run_stage = RUN_STAGE_NONE;
 #ifdef PLATFORM_WALL_SLIDE_ANIM
     plat_set_player_anim_state(PLATFORM_WALL_SLIDE_ANIM);
-#elif PLATFORM_ANIM_OVERRIDES_SET  
+#elif PLATFORM_ANIM_OVERRIDES_SET
     plat_restore_default_anim_state();
 #endif
-    plat_callback_execute(WALL_INIT);    
+    plat_callback_execute(WALL_INIT);
 }
 
 static void state_exit_wall(void) {
@@ -2433,7 +2433,7 @@ static void state_enter_knockback(void) {
     plat_drop_timer = 0;
 #ifdef PLATFORM_KNOCKBACK_ANIM
     plat_set_player_anim_state(PLATFORM_KNOCKBACK_ANIM);
-#elif PLATFORM_ANIM_OVERRIDES_SET  
+#elif PLATFORM_ANIM_OVERRIDES_SET
     plat_restore_default_anim_state();
 #endif
     plat_callback_execute(KNOCKBACK_INIT);
@@ -2443,7 +2443,7 @@ static void state_exit_knockback(void) {
     plat_vel_x = 0;
     plat_callback_execute(KNOCKBACK_END);
 }
-        
+
 static void state_update_knockback(void) {
     // Horizontal Movement --------------------------------------------
 
@@ -2455,7 +2455,7 @@ static void state_update_knockback(void) {
 
     // Vertical Movement ----------------------------------------------
 
-    // Normal gravity        
+    // Normal gravity
     plat_vel_y += plat_grav;
     plat_vel_y = MIN(plat_vel_y, plat_max_fall_vel);
     plat_delta_y += VEL_TO_SUBPX(plat_vel_y);
@@ -2465,7 +2465,7 @@ static void state_update_knockback(void) {
     move_and_collide(COL_CHECK_ALL);
 
     // Counters -------------------------------------------------------
-    
+
     COUNTER_DECREMENT(plat_knockback_timer);
     if (plat_knockback_timer != 0) {
         plat_next_state = KNOCKBACK_STATE;
@@ -2484,16 +2484,16 @@ static void state_enter_blank(void) {
     plat_jump_type = JUMP_TYPE_NONE;
 #ifdef PLATFORM_BLANK_ANIM
     plat_set_player_anim_state(PLATFORM_BLANK_ANIM);
-#elif PLATFORM_ANIM_OVERRIDES_SET  
+#elif PLATFORM_ANIM_OVERRIDES_SET
     plat_restore_default_anim_state();
 #endif
-    plat_callback_execute(BLANK_INIT);  
+    plat_callback_execute(BLANK_INIT);
 }
 
 static void state_exit_blank(void) {
     plat_vel_x = 0;
     plat_vel_y = 0;
-    plat_callback_execute(BLANK_END);    
+    plat_callback_execute(BLANK_END);
 }
 
 static void state_update_blank(void) {

--- a/src/states/shmup.c
+++ b/src/states/shmup.c
@@ -102,7 +102,7 @@ void shmup_init(void) BANKED {
     camera_offset_y = 0;
     camera_deadzone_x = 0;
     camera_deadzone_y = 0;
-    
+
     shooter_direction = PLAYER.dir;
 
     if (shooter_direction == DIR_LEFT) {
@@ -132,7 +132,7 @@ void shmup_init(void) BANKED {
     }
 
     shooter_reached_end = FALSE;
-    
+
     // Initialize camera position for unlocked movement
     IF_FREE_MOVEMENT({
         camera_x = add_signed_clamped_u16(PLAYER.pos.x, PX_TO_SUBPX(camera_offset_x),
@@ -276,7 +276,7 @@ void shmup_update(void) BANKED {
                 }
             }
         }
-        
+
         if (angle != ANGLE_0DEG && angle != ANGLE_180DEG) { // Moved horizontally
             // Step X
             tile_start = SUBPX_TO_TILE(PLAYER.pos.y + PLAYER.bounds.top);
@@ -402,7 +402,7 @@ void shmup_update(void) BANKED {
                 })
             }
         }
-    }    
+    }
 
     IF_FREE_MOVEMENT({
         // Keep player within screen bounds


### PR DESCRIPTION
Just a little bit of cleanup/normalization of non-spaced tabulations and trailing white spaces that were bugging me when I was creating patches for plugins.