### PR TITLE
Fix scene loading when it interrupts a camera shake event

### DIFF
--- a/src/core/data_manager.c
+++ b/src/core/data_manager.c
@@ -229,6 +229,7 @@ UBYTE load_scene(const scene_t * scene, UBYTE bank, UBYTE init_data) BANKED {
     scroll_x_max = scn.scroll_bounds.right;
     scroll_y_min = scn.scroll_bounds.top;
     scroll_y_max = scn.scroll_bounds.bottom;
+    scroll_offset_x = scroll_offset_y = 0;
 
     if (scene_type != SCENE_TYPE_LOGO) {
         // Load player


### PR DESCRIPTION
If the camera is shaking while a scene is being loaded, then some background tiles of the new scene might not be loaded properly, which will result in glitched graphics.
Here is an example of such glitched graphics on one of the sample projects given by GB Studio, with no engine modification at all.
<img width="480" height="428" alt="image" src="https://github.com/user-attachments/assets/32e93efd-5560-420c-8538-ff4f233236f2" />
