### PR TITLE
Change exception handling

### DIFF
--- a/include/compat.h
+++ b/include/compat.h
@@ -51,4 +51,10 @@
 #endif
 #endif
 
+#ifndef NORETURN
+#ifdef __SDCC
+#defiene NORETURN	_Noreturn
+#endif
+#endif
+
 #endif

--- a/include/core.h
+++ b/include/core.h
@@ -3,7 +3,10 @@
 
 #include <gbdk/platform.h>
 
+#include "compat.h"
+
 void core_reset(void) BANKED;
 void core_run(void) BANKED;
+NORETURN void generate_exception(UBYTE code, void const * params_offset, UBYTE params_bank) BANKED;
 
 #endif

--- a/include/vm.h
+++ b/include/vm.h
@@ -141,11 +141,6 @@ extern SCRIPT_CTX * old_executing_ctx, * executing_ctx;
 extern UBYTE vm_lock_state;
 // loaded state
 extern UBYTE vm_loaded_state;
-// exception flag and parameters
-extern UBYTE vm_exception_code;
-extern UBYTE vm_exception_params_length;
-extern UBYTE vm_exception_params_bank;
-extern const void * vm_exception_params_offset;
 
 // script core functions
 void vm_push(SCRIPT_CTX * THIS, UWORD value) OLDCALL BANKED;

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include <rand.h>
+#include <setjmp.h>
 
 #include "system.h"
 #include "interrupts.h"
@@ -40,6 +41,7 @@ extern const UBYTE bootstrap_script[];
 extern void core_reset_hook(void); 
 
 UBYTE pause_state_update;
+static jmp_buf exception_env;
 
 void core_reset(void) BANKED {
     // cleanup core stuff
@@ -58,131 +60,132 @@ void core_reset(void) BANKED {
     music_init_events(FALSE);
 }
 
+
+NORETURN void generate_exception(UBYTE code, void const * params_offset, UBYTE params_bank) BANKED {
+	UBYTE fade_in = TRUE;
+	switch (code) {
+		case EXCEPTION_RESET: {
+			// remove previous LCD ISR's
+			remove_LCD_ISRs();
+			// reset everything
+			core_reset_hook();
+			// kill all threads, but don't clear VM memory
+			script_runner_init(FALSE);
+			// load start scene
+			fade_in = !(load_scene(start_scene.ptr, start_scene.bank, TRUE));
+			// load initial player
+			load_player();
+			break;
+		}
+		case EXCEPTION_CHANGE_SCENE: {
+			// remove previous LCD ISR's
+			remove_LCD_ISRs();
+			// kill all threads, but don't clear variables 
+			script_runner_init(FALSE);
+			// reset timers on scene change
+			timers_init(FALSE);
+			// reset input events on scene change
+			events_init(FALSE);
+			// reset music events
+			music_init_events(FALSE);
+			// load scene
+			far_ptr_t scene;
+			ReadBankedFarPtr(&scene, params_offset, params_bank);
+			fade_in = !(load_scene(scene.ptr, scene.bank, TRUE));
+			break;
+		}
+		case EXCEPTION_SAVE: {
+			data_save(ReadBankedUBYTE(params_offset, params_bank));
+			goto skip_init;
+		}
+		case EXCEPTION_LOAD: {
+			fade_out_modal();
+			// remove previous LCD ISR's
+			remove_LCD_ISRs();
+			// load game state from SRAM
+			vm_loaded_state = data_load(ReadBankedUBYTE(params_offset, params_bank));
+			load_scene(current_scene.ptr, current_scene.bank, FALSE);
+			fade_in = FALSE;
+			break;
+		}
+		default: {
+			// nothing: suppress any unknown exception
+			goto skip_init;
+		}
+	}
+
+	CRITICAL {
+		switch (scene_LCD_type) {
+			case LCD_parallax: 
+				add_LCD(parallax_LCD_isr);
+				break;
+			case LCD_fullscreen:
+				add_LCD(fullscreen_LCD_isr);
+				break;
+			default:
+				add_LCD(simple_LCD_isr);
+				break;
+		}
+		LYC_REG = 0u;
+	}
+	if (!hide_sprites) SHOW_SPRITES;    // show sprites back if we switched LCD ISR while sprites were hidden 
+
+	pause_state_update = false;
+	
+	player_init();
+	state_init();
+	toggle_shadow_OAM();
+	camera_update();
+	scroll_repaint();
+	activate_persistent_actors();
+	actors_update();
+	actors_render();
+
+	activate_shadow_OAM();
+
+	if (fade_in) fade_in_modal();
+	
+skip_init:
+	longjmp(exception_env, 1);
+}
+
 void process_VM(void) {
+	setjmp(exception_env);
     while (TRUE) {
-        switch (script_runner_update()) {
-            case RUNNER_DONE:
-            case RUNNER_IDLE: {                
-                input_update();
-                if (INPUT_SOFT_RESTART) {
-                    // kill all threads and clear VM memory 
-                    script_runner_init(TRUE);
-                    // execute bootstrap script              
-                    script_execute(BANK(bootstrap_script), bootstrap_script, 0, 0);
-                    break;
-                }
-                if (!VM_ISLOCKED()) {
-                    if (joy != 0) events_update();                      // update joypad events (must be the first)
-                    if (!pause_state_update) state_update();                                     // update current scene, depending on its type
-                    if ((game_time & 0x0F) == 0x00) timers_update();    // update timers
-                    music_events_update();                              // update music events
-                }
+        if (script_runner_update()) {              
+			input_update();
+			if (INPUT_SOFT_RESTART) {
+				// kill all threads and clear VM memory 
+				script_runner_init(TRUE);
+				// execute bootstrap script              
+				script_execute(BANK(bootstrap_script), bootstrap_script, 0, 0);
+				continue;
+			}
+			if (!VM_ISLOCKED()) {
+				if (joy != 0) events_update();                      // update joypad events (must be the first)
+				if (!pause_state_update) state_update();                                     // update current scene, depending on its type
+				if ((game_time & 0x0F) == 0x00) timers_update();    // update timers
+				music_events_update();                              // update music events
+			}
 
-                toggle_shadow_OAM();                
+			toggle_shadow_OAM();                
 
-                camera_update();
-                scroll_update();
-                actors_update();
-                actors_render();
-                if (projectiles_active_head) {
-                    projectiles_update();                               // update projectiles
-                    projectiles_render();                               // render projectiles
-                }
-                ui_update();
-                actors_handle_player_collision();
+			camera_update();
+			scroll_update();
+			actors_update();
+			actors_render();
+			if (projectiles_active_head) {
+				projectiles_update();                               // update projectiles
+				projectiles_render();                               // render projectiles
+			}
+			ui_update();
+			actors_handle_player_collision();
 
-                game_time++;
+			game_time++;
 
-                activate_shadow_OAM();
+			activate_shadow_OAM();
 
-                wait_vbl_done();
-                break;
-            }
-            case RUNNER_BUSY: break;
-            case RUNNER_EXCEPTION: {
-                UBYTE fade_in = TRUE;
-                switch (vm_exception_code) {
-                    case EXCEPTION_RESET: {
-                        // remove previous LCD ISR's
-                        remove_LCD_ISRs();
-                        // reset everything
-                        core_reset_hook();
-                        // kill all threads, but don't clear VM memory
-                        script_runner_init(FALSE);
-                        // load start scene
-                        fade_in = !(load_scene(start_scene.ptr, start_scene.bank, TRUE));
-                        // load initial player
-                        load_player();
-                        break;
-                    }
-                    case EXCEPTION_CHANGE_SCENE: {
-                        // remove previous LCD ISR's
-                        remove_LCD_ISRs();
-                        // kill all threads, but don't clear variables 
-                        script_runner_init(FALSE);
-                        // reset timers on scene change
-                        timers_init(FALSE);
-                        // reset input events on scene change
-                        events_init(FALSE);
-                        // reset music events
-                        music_init_events(FALSE);
-                        // load scene
-                        far_ptr_t scene;
-                        ReadBankedFarPtr(&scene, vm_exception_params_offset, vm_exception_params_bank);
-                        fade_in = !(load_scene(scene.ptr, scene.bank, TRUE));
-                        break;
-                    }
-                    case EXCEPTION_SAVE: {
-                        data_save(ReadBankedUBYTE(vm_exception_params_offset, vm_exception_params_bank));
-                        continue;
-                    }
-                    case EXCEPTION_LOAD: {
-                        fade_out_modal();
-                        // remove previous LCD ISR's
-                        remove_LCD_ISRs();
-                        // load game state from SRAM
-                        vm_loaded_state = data_load(ReadBankedUBYTE(vm_exception_params_offset, vm_exception_params_bank));
-                        load_scene(current_scene.ptr, current_scene.bank, FALSE);
-                        fade_in = FALSE;
-                        break;
-                    }
-                    default: {
-                        // nothing: suppress any unknown exception
-                        continue;
-                    }
-                }
-
-                CRITICAL {
-                    switch (scene_LCD_type) {
-                        case LCD_parallax: 
-                            add_LCD(parallax_LCD_isr);
-                            break;
-                        case LCD_fullscreen:
-                            add_LCD(fullscreen_LCD_isr);
-                            break;
-                        default:
-                            add_LCD(simple_LCD_isr);
-                            break;
-                    }
-                    LYC_REG = 0u;
-                }
-                if (!hide_sprites) SHOW_SPRITES;    // show sprites back if we switched LCD ISR while sprites were hidden 
-
-                pause_state_update = false;
-                
-                player_init();
-                state_init();
-                toggle_shadow_OAM();
-                camera_update();
-                scroll_repaint();
-                activate_persistent_actors();
-                actors_update();
-                actors_render();
-
-                activate_shadow_OAM();
-
-                if (fade_in) fade_in_modal();
-            }
+			wait_vbl_done();
         }
     }
 }

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -9,6 +9,7 @@
 #include "vm.h"
 #include "math.h"
 #include "compat.h"
+#include "core.h"
 
 BANKREF(VM_MAIN)
 
@@ -26,11 +27,6 @@ SCRIPT_CTX * old_executing_ctx, * executing_ctx;
 UBYTE vm_lock_state;
 // loaded state
 UBYTE vm_loaded_state;
-// exception flsg
-UBYTE vm_exception_code;
-UBYTE vm_exception_params_length;
-UBYTE vm_exception_params_bank;
-const void * vm_exception_params_offset;
 
 // we need BANKED functions here to have two extra words before arguments
 // we will put VM stuff there
@@ -444,11 +440,9 @@ void vm_unlock(SCRIPT_CTX * THIS) OLDCALL BANKED {
 
 // raises VM exception
 void vm_raise(SCRIPT_CTX * THIS, UBYTE code, UBYTE size) OLDCALL BANKED {
-    vm_exception_code = code;
-    vm_exception_params_length = size;
-    vm_exception_params_bank = THIS->bank;
-    vm_exception_params_offset = THIS->PC;
+    void const * params_offset = THIS->PC;
     THIS->PC += size;
+	generate_exception(code, params_offset, THIS->bank);
 }
 
 // sets variable indirect
@@ -764,7 +758,6 @@ UBYTE script_runner_update(void) NONBANKED {
     waitable = TRUE;
     counter = INSTRUCTIONS_PER_QUANT;
     while (executing_ctx) {
-        vm_exception_code = EXCEPTION_CODE_NONE;
         executing_ctx->waitable = FALSE;
         if ((executing_ctx->terminated != FALSE) || (!VM_STEP(executing_ctx))) {
             // update lock state
@@ -779,11 +772,6 @@ UBYTE script_runner_update(void) NONBANKED {
             // next context
             if (old_executing_ctx) executing_ctx = old_executing_ctx->next; else executing_ctx = first_ctx;
         } else {
-            // check exception
-            if (vm_exception_code) {
-                SWITCH_ROM(_save);
-                return RUNNER_EXCEPTION;
-            }
             // loop until waitable state or quant is expired
             if (!(executing_ctx->waitable) && (counter--)) continue;
             // exit while loop if context switching is locked
@@ -795,9 +783,6 @@ UBYTE script_runner_update(void) NONBANKED {
         }
     }
     SWITCH_ROM(_save);
-
-    // return 0 if all threads are finished
-    if (first_ctx == 0) return RUNNER_DONE;
-    // return 1 if all threads in waitable state else return 2
-    if (waitable) return RUNNER_IDLE; else return RUNNER_BUSY;
+	
+	return waitable;
 }

--- a/src/core/vm_scene.c
+++ b/src/core/vm_scene.c
@@ -7,6 +7,7 @@
 
 #include "actor.h"
 #include "bankdata.h"
+#include "core.h"
 #include "data_manager.h"
 
 BANKREF(VM_SCENE)
@@ -19,12 +20,9 @@ void vm_scene_push(void) OLDCALL BANKED {
 }
 
 static void raise_change_scene_exception(void) {
-    vm_exception_code = EXCEPTION_CHANGE_SCENE;
-    vm_exception_params_length = sizeof(far_ptr_t);
-    vm_exception_params_bank = 1; // any bank
-    vm_exception_params_offset = &scene_stack_ptr->scene;
     PLAYER.pos = scene_stack_ptr->pos;
     PLAYER.dir = scene_stack_ptr->dir;
+	generate_exception(EXCEPTION_CHANGE_SCENE, &scene_stack_ptr->scene, 0);
 }
 
 void vm_scene_pop(void) OLDCALL BANKED {


### PR DESCRIPTION
Exceptions are now handled using longjumps instead of checking after each vm instructions whether that instruction generated an exception.
By dissassembling the compiled code generated by sdcc for script_runner_update, this change will save at least 13 cycles per vm instruction.

Now to generate a vm exception from native code one would have to call generate_exception(exception_code, params_offset, params_bank), instead of setting the 4 following global variable vm_exception_code, vm_exception_params_offset, vm_exception_params_bank and vm_exception_params_length.
As such these 4 global variable don't need to exist anymore, which saves 5 bytes of RAM, outweighing the 4 byte memory cost required by the jump buffer.
All code that is after a call to generate_exception will never be executed because after generate_exception is done with handling the exception, it calls longjmp to resume the execution of the program in process_VM. Hence the new NORETURN macro in compat.h.

Because of this PR, script_runner_update would only need to return 3 different return code : RUNNER_DONE, RUNNER_IDLE and RUNNER_BUSY.
However process_VM doesn't make a difference between RUNNER_DONE and RUNNER_IDLE.
As such, to avoid the error "conditional flow changed by optimizer: so said EVELYN the modified DOG", i made it such that script_runner_update returns whether all thread are in a waitable state or not.
This simplifies the logic to determine the return value of script_runner_update, which saves a few additional cycle every frame.

All of the content of this PR has been tested on the sample project that comes with GB Studio, as such all of the following works as intended :
- exception reset
- exception change scene
- exception save
- exception load save
- the scene stack
Which should be all that has been affected by this PR.