### PR TITLE
fix: prevent DMG text corruption 

### DIFF
--- a/include/ui.h
+++ b/include/ui.h
@@ -67,6 +67,8 @@ extern UBYTE * text_scroll_addr;
 extern UBYTE text_scroll_width, text_scroll_height;
 extern UBYTE text_scroll_fill;
 
+extern UBYTE tile_cache_letters[];
+
 extern UBYTE text_sound_mask;
 extern UBYTE text_sound_bank;
 extern const UBYTE * text_sound_data;

--- a/src/core/ui.c
+++ b/src/core/ui.c
@@ -78,6 +78,8 @@ const UBYTE * text_sound_data;
 UBYTE overlay_priority;
 UBYTE text_palette;
 
+UBYTE tile_cache_letters[TEXT_BUFFER_LEN];
+
 void ui_init(void) BANKED {
     vwf_direction               = UI_PRINT_LEFTTORIGHT;
     vwf_current_font_idx        = 0;
@@ -98,6 +100,7 @@ void ui_init(void) BANKED {
     ui_current_tile_bank        = 0;
     ui_prev_tile                = TEXT_BUFFER_START;
     ui_prev_tile_bank           = 0;
+    memset(tile_cache_letters, 0xFF, TEXT_BUFFER_LEN);
 
     ui_set_pos(0, MENU_CLOSED_Y);
 
@@ -205,6 +208,7 @@ void ui_set_start_tile(UBYTE start_tile, UBYTE start_tile_bank) BANKED {
     ui_prev_tile_bank = ui_current_tile_bank = start_tile_bank;
     vwf_current_offset = 0;
     memset(vwf_tile_data, text_bkg_fill, sizeof(vwf_tile_data));
+    memset(tile_cache_letters, 0xFF, TEXT_BUFFER_LEN);
 }
 
 void ui_print_shift_char(void * dest, const void * src, UBYTE bank) OLDCALL;
@@ -255,6 +259,24 @@ UBYTE ui_print_render(const unsigned char ch) {
         return FALSE;
     } else {
         if (vwf_current_offset) ui_next_tile();
+        if (!_is_CGB) {
+            UBYTE cached = 0xFF;
+            for (UBYTE i = 0; i != TEXT_BUFFER_LEN; i++) {
+                if (tile_cache_letters[i] == letter) { cached = TEXT_BUFFER_START + i; break; }
+            }
+            if (cached != 0xFF) {
+                ui_prev_tile = cached;
+                ui_prev_tile_bank = 0;
+                vwf_current_offset = 0u;
+                return TRUE;
+            }
+            {
+                UBYTE slot = ui_current_tile - TEXT_BUFFER_START;
+                if (slot < TEXT_BUFFER_LEN) {
+                    tile_cache_letters[slot] = letter;
+                }
+            }
+        }
         ui_load_tile(bitmap, vwf_current_font_bank);
         ui_next_tile();
         vwf_current_offset = 0u;
@@ -331,6 +353,7 @@ UBYTE ui_draw_text_buffer_char(void) BANKED {
                 if ((vwf_current_offset) && ((old_flags & FONT_VWF) != 0) && ((vwf_current_font_desc.attr & FONT_VWF) == 0)) {
                     ui_dest_ptr++;
                 }
+                memset(tile_cache_letters, 0xFF, TEXT_BUFFER_LEN);
                 break;
             }
             case 0x03:


### PR DESCRIPTION
While testing CrankBoy I noticed a bug in the game `Life's Too Short: A Christmas Spirit`. The first line of text was corrupting. I first thought that might have been a CrankBoy issue, but when I opened the game in SameBoy the same error surfaced, when running the game in `DMG` emulation. But not when running in `CGB`.

The root cause is that DMG has only 52 tiles (`0xCC-0xFF`) for character rendering. Each unique letter allocates a new tile. So the 68-character dialog with only 20 unique letters uses 68 tiles on DMG, therefore exceeding the pool and overwriting old tile data.

I added a tile cache for monospaced fonts.  A 52-byte array mapping each tile slot to the glyph it stores. When the same letter repeats, the existing tile is reused instead of allocating a new one.

### `CGB` Mode:

<img width="416" height="334" alt="CleanShot 2026-05-15 at 22 45 21" src="https://github.com/user-attachments/assets/5d201ea4-e24e-406c-8716-0cfd689ce043" />

### `DMG` Mode w/o fix:
<img width="416" height="324" alt="CleanShot 2026-05-15 at 22 50 32" src="https://github.com/user-attachments/assets/828888fc-5702-45d4-9a30-c899705706ee" />


### `DMG` Mode w/ fix:

<img width="416" height="334" alt="CleanShot_2026-05-15_at_22 17 38" src="https://github.com/user-attachments/assets/be4c2f63-a3a7-4d6f-9213-80cae1affbd1" />

<img width="400" height="240" alt="playdate-20260515-221925" src="https://github.com/user-attachments/assets/756668be-8f2d-4580-9012-248036261fc1" />
