### PR TITLE
Fix actors getting stuck in Move To when moving toward coordinate 0

### DIFF
--- a/src/core/vm_actor.c
+++ b/src/core/vm_actor.c
@@ -227,6 +227,7 @@ void vm_actor_move_to(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
         new_dir = CHK_FLAG(THIS->flags, MOVE_DIR_H) ? DIR_LEFT : DIR_RIGHT;
 
         // Move actor horizontally
+        UWORD prev_x = actor->pos.x;
         actor->pos.x += new_dir == DIR_LEFT ? -actor->move_speed : actor->move_speed;
 
         // Check for actor collision
@@ -248,9 +249,9 @@ void vm_actor_move_to(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
             actor_set_dir(actor, new_dir, TRUE);
         }
 
-        // Check if overshot destination
+        // Check if overshot destination or wrapped past zero
         if (
-            (new_dir == DIR_LEFT && (actor->pos.x <= params->X)) || // Overshot left
+            (new_dir == DIR_LEFT && (actor->pos.x <= params->X || actor->pos.x > prev_x)) || // Overshot left
             (new_dir == DIR_RIGHT && (actor->pos.x >= params->X))   // Overshot right
         ) {
             // Reached Horizontal Destination
@@ -266,6 +267,7 @@ void vm_actor_move_to(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
         new_dir = CHK_FLAG(THIS->flags, MOVE_DIR_V) ? DIR_UP : DIR_DOWN;
 
         // Move actor vertically
+        UWORD prev_y = actor->pos.y;
         actor->pos.y += new_dir == DIR_UP ? -actor->move_speed : actor->move_speed;
 
         // Check for actor collision
@@ -287,9 +289,9 @@ void vm_actor_move_to(SCRIPT_CTX * THIS, INT16 idx) OLDCALL BANKED {
             actor_set_dir(actor, new_dir, TRUE);
         }
 
-        // Check if overshot destination
+        // Check if overshot destination or wrapped past zero
         if (
-            (new_dir == DIR_UP && (actor->pos.y <= params->Y)) || // Overshot above
+            (new_dir == DIR_UP && (actor->pos.y <= params->Y || actor->pos.y > prev_y)) || // Overshot above
             (new_dir == DIR_DOWN &&  (actor->pos.y >= params->Y)) // Overshot below
          ) {
             actor->pos.y = params->Y;
@@ -650,6 +652,7 @@ void vm_actor_move_to_x(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKED
         return;
     } else if (params->X < actor->pos.x) {
         // Moving left
+        UWORD prev_x = actor->pos.x;
         actor->pos.x -= actor->move_speed;
 
         // Check for actor collision
@@ -661,8 +664,8 @@ void vm_actor_move_to_x(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKED
             return;
         }
 
-        // Check if overshot destination
-        if (actor->pos.x <= params->X) {
+        // Check if overshot destination or wrapped past zero
+        if (actor->pos.x <= params->X || actor->pos.x > prev_x) {
             // Reached Horizontal Destination
             actor->pos.x = params->X;
             actor_set_anim_idle(actor);
@@ -717,6 +720,7 @@ void vm_actor_move_to_y(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKED
         return;
     } else if (params->Y < actor->pos.y) {
         // Moving upwards
+        UWORD prev_y = actor->pos.y;
         actor->pos.y -= actor->move_speed;
 
         // Check for actor collision
@@ -728,8 +732,8 @@ void vm_actor_move_to_y(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKED
             return;
         }
 
-        // Check if overshot destination
-        if (actor->pos.y <= params->Y) {
+        // Check if overshot destination or wrapped past zero
+        if (actor->pos.y <= params->Y || actor->pos.y > prev_y) {
             actor->pos.y = params->Y;
             actor_set_anim_idle(actor);
             return;
@@ -781,6 +785,7 @@ void vm_actor_move_to_xy(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKE
     if (!reached_x) {
         if (params->X < actor->pos.x) {
             // Moving left
+            UWORD prev_x = actor->pos.x;
             actor->pos.x -= actor->move_speed;
 
             // Check for actor collision
@@ -791,8 +796,8 @@ void vm_actor_move_to_xy(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKE
                 reached_x = TRUE;
             }
 
-            // Check if overshot destination
-            if (actor->pos.x <= params->X) {
+            // Check if overshot destination or wrapped past zero
+            if (actor->pos.x <= params->X || actor->pos.x > prev_x) {
                 // Reached Horizontal Destination
                 actor->pos.x = params->X;
                 reached_x = TRUE;
@@ -821,6 +826,7 @@ void vm_actor_move_to_xy(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKE
     if (!reached_y) {
         if (params->Y < actor->pos.y) {
             // Moving upwards
+            UWORD prev_y = actor->pos.y;
             actor->pos.y -= actor->move_speed;
 
             // Check for actor collision
@@ -831,8 +837,8 @@ void vm_actor_move_to_xy(SCRIPT_CTX * THIS, INT16 idx, UBYTE attr) OLDCALL BANKE
                 reached_y = TRUE;
             }
 
-            // Check if overshot destination
-            if (actor->pos.y <= params->Y) {
+            // Check if overshot destination or wrapped past zero
+            if (actor->pos.y <= params->Y || actor->pos.y > prev_y) {
                 actor->pos.y = params->Y;
                 reached_y = TRUE;
             }


### PR DESCRIPTION
 **Problem**
All Move To variants (`vm_actor_move_to` and `vm_actor_move_to_x/y/xy`) step the position before checking arrival:
 ```c
 actor->pos.y -= actor->move_speed;
 ...
 if (actor->pos.y <= params->Y) { /* snap */ }
 ```
 `pos` is unsigned (`upoint16_t`). When the target is 0 (or closer than `move_speed`) and the remaining distance is not an exact multiple of `move_speed`, the subtraction wraps to ~65500 and the unsigned comparison can never become true. The instruction reloops forever (`THIS->PC -= ...`), permanently hanging that script thread.

 Repro: place an actor at any tile-aligned position, set move speed 0.6 (19 subpx), Actor Move To y=0. The actor never arrives and no later events run. Speeds 0.5/1 (16/32 subpx) appear fine only because they evenly divide tile-aligned distances.

 **Fix**
 Detect the wrap: after the subtraction, a result greater than the previous position can only mean the value wrapped below zero, so treat it as arrival. This keeps the existing statement order (including the collision check path) unchanged. Only the toward-zero branches are affected; the increasing branches cannot wrap with valid scene coordinates (max 2040px = 65280 subpx + max speed < 65536).

 Tested on a real project (GB Studio 4.2): before the patch, actors with speeds 19/22/25/28 hang on Move To y=0; after the patch they arrive and the script continues. Speeds 16/32 behave identically before/after (regression check).