### PR TITLE
*Steps THIS->PC even if failed to start a thread.

### DIFF
--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -155,6 +155,8 @@ void vm_beginthread(DUMMY0_t dummy0, DUMMY1_t dummy1, SCRIPT_CTX * THIS, UBYTE b
             *(ctx->stack_ptr++) = (UWORD)A;
             THIS->PC += 2;
         }
+    } else {
+        THIS->PC += nargs * 2;
     }
 }
 //


### PR DESCRIPTION
In `vm_beginthread`, `THIS->PC` was not stepped when nargs!=0 and ctx==NULL (failed to start a thread).

This edit handles `THIS->PC` with proper steps even if ctx==NULL.