### PR TITLE
Fix for #1733: Fill overlay tiles that are not visible with fill color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ __pycache__
 /test/*/*.bmp
 /third-party/*/build
 /unused
+.DS_Store

--- a/src/core/vm_ui.c
+++ b/src/core/vm_ui.c
@@ -217,7 +217,11 @@ void vm_overlay_clear(SCRIPT_CTX * THIS, UBYTE x, UBYTE y, UBYTE w, UBYTE h, UBY
 // shows overlay
 void vm_overlay_show(SCRIPT_CTX * THIS, UBYTE pos_x, UBYTE pos_y, UBYTE color, UBYTE options) OLDCALL BANKED {
     THIS;
-    if ((pos_x < 20u) && (pos_y < 18u)) vm_overlay_clear(THIS, 0, 0, 20u - pos_x, 18u - pos_y, color, options);
+    UBYTE vis_w = (pos_x < 20u) ? 20u - pos_x : 0u;
+    UBYTE vis_h = (pos_y < 18u) ? 18u - pos_y : 0u;
+    if (vis_w < 20u) vm_overlay_clear(THIS, vis_w, 0u, 20u - vis_w, 18u, color, 0u);
+    if (vis_h < 18u && vis_w) vm_overlay_clear(THIS, 0u, vis_h, vis_w, 18u - vis_h, color, 0u);
+    if (vis_w && vis_h) vm_overlay_clear(THIS, 0u, 0u, vis_w, vis_h, color, options);
     ui_set_pos(pos_x << 3, pos_y << 3);
 }
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
 [x] The commit message follows our guidelines
 [x] Tests for the changes have been added (for bug fixes / features)
I manually tested this change with the engine eject in GB Studio. I tested both monochrome and color mode. I tested multiple permutations of X, Y and Fill Color values for the Show Overlay event. I tested the same permuations using the GBVM event to draw the frame, for example:
```
VM_OVERLAY_SHOW 18, 16, .UI_COLOR_WHITE, .UI_DRAW_FRAME
```
All of my tests behaved as expected.

 [x] Docs have been added / updated (for bug fixes / features)
No document changes needed.

This is my first gbvm PR. I chose to make a separate fork of your gbvm repo. Hopefully this is correct. If not, let me know the proper process and I can redo it.

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix for #1733: overlay movements use wrong overlay color

## What is the current behavior? (You can also link to an open issue here)
The Show Overlay event only fills the overlay tiles that are visible (i.e. in the 20X18 window). The rest of the tiles are not initiated so they contain garbage data. After using the Overlay Move To event, the rest of these tiles can be seen in the window and, since they contain garbage data, they usually do not match the fill color of Black or White.

## What is the new behavior (if this is a feature change)?
I first fill all of the not visible tiles with the appropriate fill color, setting the fourth option parameter to zero. Then, I let the visible tiles be filled as they were in the original code. This way, it fixes both the current bug with the Show Overlay event and it also makes sure that, if a developer decides to use the GBVM Event to call `VM_OVERLAY_SHOW` with the options parameter defined, for example:
```
VM_OVERLAY_SHOW 18, 16, .UI_COLOR_WHITE, .UI_DRAW_FRAME
```
*and* still decides to use the Overlay Move To event -- although I don't know why anyone would do that -- it will make sure no garbage data tiles show in that scenario as well.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

## Other information:
I added to the .gitignore file to ignore the Mac-based .DS_Store file.